### PR TITLE
Use call instead of apply for cached results.

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -39,7 +39,7 @@ var caching = function (args) {
             if (err && (!self.ignoreCacheErrors)) {
                 cb(err);
             } else if (result) {
-                cb.apply(null, result);
+                cb.call(cb, null, result);
             } else if (self.queues[key]) {
                 self.queues[key].push(cb);
             } else {
@@ -50,7 +50,8 @@ var caching = function (args) {
                     if (work_args[0]) { // assume first arg is an error
                         return cb(work_args[0]);
                     }
-                    self.store.set(key, work_args, function (err) {
+                    // Subsequently assume second arg is result.
+                    self.store.set(key, work_args[1], function (err) {
                         if (err && (!self.ignoreCacheErrors)) {
                             return cb(err);
                         }


### PR DESCRIPTION
In the cache manager's work callback it is assumed that `work_args` is an array of `[ err, result ]`; however, the underlaying cache engine's `set` method is called with the full array of work args, not just the result. This results in the cache value being stored as an array of `[ err, result ]`. I don't believe that this is desirable but perhaps I'm missing some of the intent here. This went undetected in testing because the cached result was calling back with `result`: the previously stored array.

This PR ensures that the underlaying cache engine is storing only the cacheable result and not the error parameter that was returned by the `work` method.
