### PR TITLE
Prevent stalemate by executing callbacks on error

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -49,7 +49,7 @@ var caching = function (args) {
                     var work_args = Array.prototype.slice.call(arguments, 0);
                     if (work_args[0]) { // assume first arg is an error
                         self.queues[key].forEach(function (done) {
-                            done.apply(null, work_args);
+                            done.call(null, work_args[0]);
                         });
                         delete self.queues[key];
                         return;
@@ -61,13 +61,10 @@ var caching = function (args) {
                                 done.call(null, err);
                             });
                         }
-                        else if (!err) {
+                        else {
                             self.queues[key].forEach(function (done) {
                                 done.apply(null, work_args);
                             });
-                        }
-                        else {
-                          return;
                         }
 
                         delete self.queues[key];


### PR DESCRIPTION
Let me start this with I'm unsure if the behavior I'm changing was intentional, so if my approach to using this module needs to change I'm open to this PR being more of a discussion than a code dump :smile: 

Here's the situation I observed which led to this change:
1. Request is made for nonexistent value
   - cache manager queues the key
   - underlaying cache engine returns an empty result
   - cache manager attempts to set empty result and errors
   - callback is executed with error argument but queue still exists
2. Another request is made for the same nonexistent value
   - cache manager queues the key
   - because the queue exists the callback is indefinitely in limbo

This is particularly problematic for web servers that use a wrap function and depend on a callback from wrap to be able to complete the web request.

This change will execute all queued callbacks and remove the callbacks queue in the event of an error either on return from the worker or on the store set.
