### PR TITLE
Add keyPrefix to mDel, mGet and ttl, Change clusterStore options type to include customOptions and readd cluster tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,20 @@ services:
     image: redis
     ports:
       - '6379:6379'
+  redis-cluster:
+    image: redis
+    command: >
+      sh -c "
+      echo 'Starting Redis server...' &&
+      redis-server --port 6380 --cluster-enabled yes &
+      sleep 5 &&
+      echo 'Creating cluster...' &&
+      redis-cli -p 6380 cluster addslotsrange 0 16383 &&
+      echo 'Cluster created.' &&
+      wait
+      "    
+    ports:
+      - '6380:6380'
   redisio:
     image: redis
     ports:

--- a/packages/cache-manager-redis-yet/test/cluster.test.ts
+++ b/packages/cache-manager-redis-yet/test/cluster.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import cacheManager from 'cache-manager';
-import { redisClusterStore, RedisCache } from '../src';
+import { caching } from 'cache-manager';
+import { redisClusterStore, RedisCache, NoCacheableError } from '../src';
 import { RedisClusterOptions, RedisClusterType } from 'redis';
 
 let redisCache: RedisCache<RedisClusterType>;
@@ -9,22 +9,21 @@ let customRedisCache: RedisCache<RedisClusterType>;
 // TODO: https://github.com/redis/node-redis/issues/2213
 const config: RedisClusterOptions & { ttl: number } = {
   rootNodes: [
-    { url: 'redis://redis-c0:6379' },
-    { url: 'redis://redis-c1:6379' },
+    { url: 'redis://localhost:6380' },
   ],
   ttl: 0,
 };
 
 beforeEach(async () => {
-  redisCache = cacheManager.caching({
-    store: await redisClusterStore(config),
-    ...config,
-  }) as RedisCache<RedisClusterType>;
+  
+  redisCache = await caching(
+    redisClusterStore, config
+  );
 
   await redisCache.reset();
   const conf = {
     ...config,
-    isCacheableValue: (val: unknown) => {
+    isCacheable: (val: unknown) => {
       if (val === undefined) {
         // allow undefined
         return true;
@@ -32,14 +31,12 @@ beforeEach(async () => {
         // disallow FooBarString
         return false;
       }
-      return redisCache.store.isCacheableValue(val);
+      return redisCache.store.isCacheable(val);
     },
   };
-  customRedisCache = cacheManager.caching({
-    store: await redisClusterStore(conf),
-    ...conf,
-  }) as RedisCache<RedisClusterType>;
-
+  customRedisCache = await caching(
+    redisClusterStore, conf
+  );
   await customRedisCache.reset();
 });
 
@@ -51,7 +48,7 @@ describe('set', () => {
     expect(redisCache.set('foo', 'bar', config.ttl)).resolves.toBeUndefined());
 
   it('should store a value with a infinite ttl', () =>
-    expect(redisCache.set('foo', 'bar', { ttl: 0 })).resolves.toBeUndefined());
+    expect(redisCache.set('foo', 'bar', 0)).resolves.toBeUndefined());
 
   it('should not be able to store a null value (not cacheable)', () =>
     expect(redisCache.set('foo2', null)).rejects.toBeDefined());
@@ -64,23 +61,23 @@ describe('set', () => {
 
   it('should not store an invalid value', () =>
     expect(redisCache.set('foo1', undefined)).rejects.toStrictEqual(
-      new Error('"undefined" is not a cacheable value'),
+      new NoCacheableError('"undefined" is not a cacheable value'),
     ));
 
-  it('should store an undefined value if permitted by isCacheableValue', async () => {
-    expect(customRedisCache.store.isCacheableValue(undefined)).toBe(true);
+  it('should store an undefined value if permitted by isCacheable', async () => {
+    expect(customRedisCache.store.isCacheable(undefined)).toBe(true);
     await customRedisCache.set('foo3', undefined);
   });
 
-  it('should not store a value disallowed by isCacheableValue', async () => {
-    expect(customRedisCache.store.isCacheableValue('FooBarString')).toBe(false);
+  it('should not store a value disallowed by isCacheable', async () => {
+    expect(customRedisCache.store.isCacheable('FooBarString')).toBe(false);
     await expect(
       customRedisCache.set('foobar', 'FooBarString'),
     ).rejects.toBeDefined();
   });
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.set('foo', 'bar')).rejects.toBeDefined();
   });
 });
@@ -88,8 +85,8 @@ describe('set', () => {
 describe('mset', () => {
   it('should store a value without ttl', () =>
     redisCache.store.mset([
-      ['foo', 'bar'],
-      ['foo2', 'bar2'],
+      ['{foo}', 'bar'],
+      ['{foo}2', 'bar2'],
     ]));
 
   it(
@@ -97,8 +94,8 @@ describe('mset', () => {
     () =>
       redisCache.store.mset(
         [
-          ['foo', 'bar'],
-          ['foo2', 'bar2'],
+          ['{foo}', 'bar'],
+          ['{foo}2', 'bar2'],
         ],
         60,
       ),
@@ -107,10 +104,10 @@ describe('mset', () => {
 
   it('should store a value with a infinite ttl', async () => {
     await redisCache.store.mset([
-      ['foo', 'bar'],
-      ['foo2', 'bar2'],
+      ['{foo}', 'bar'],
+      ['{foo}2', 'bar2'],
     ]);
-    await expect(redisCache.store.ttl('foo')).resolves.toEqual(-1);
+    await expect(redisCache.store.ttl('{foo}')).resolves.toEqual(-1);
   });
 
   it('should not be able to store a null value (not cacheable)', () =>
@@ -118,10 +115,10 @@ describe('mset', () => {
 
   it('should store a value without callback', async () => {
     await redisCache.store.mset([
-      ['foo', 'baz'],
-      ['foo2', 'baz2'],
+      ['{foo}', 'baz'],
+      ['{foo}2', 'baz2'],
     ]);
-    await expect(redisCache.store.mget('foo', 'foo2')).resolves.toStrictEqual([
+    await expect(redisCache.store.mget('{foo}', '{foo}2')).resolves.toStrictEqual([
       'baz',
       'baz2',
     ]);
@@ -130,26 +127,26 @@ describe('mset', () => {
   it('should not store an invalid value', () =>
     expect(redisCache.store.mset([['foo1', undefined]])).rejects.toBeDefined());
 
-  it('should store an undefined value if permitted by isCacheableValue', async () => {
-    expect(customRedisCache.store.isCacheableValue(undefined)).toBe(true);
+  it('should store an undefined value if permitted by isCacheable', async () => {
+    expect(customRedisCache.store.isCacheable(undefined)).toBe(true);
     await customRedisCache.store.mset([
-      ['foo3', undefined],
-      ['foo4', undefined],
+      ['{foo}3', undefined],
+      ['{foo}4', undefined],
     ]);
     await expect(
-      customRedisCache.store.mget('foo3', 'foo4'),
+      customRedisCache.store.mget('{foo}3', '{foo}4'),
     ).resolves.toStrictEqual(['undefined', 'undefined']);
   });
 
-  it('should not store a value disallowed by isCacheableValue', async () => {
-    expect(customRedisCache.store.isCacheableValue('FooBarString')).toBe(false);
+  it('should not store a value disallowed by isCacheable', async () => {
+    expect(customRedisCache.store.isCacheable('FooBarString')).toBe(false);
     await expect(
       customRedisCache.store.mset([['foobar', 'FooBarString']]),
     ).rejects.toBeDefined();
   });
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.store.mset([['foo', 'bar']])).rejects.toBeDefined();
   });
 });
@@ -159,21 +156,21 @@ describe('mget', () => {
     const value = 'bar';
     const value2 = 'bar2';
     await redisCache.store.mset([
-      ['foo', value],
-      ['foo2', value2],
+      ['{foo}', value],
+      ['{foo}2', value2],
     ]);
-    await expect(redisCache.store.mget('foo', 'foo2')).resolves.toStrictEqual([
+    await expect(redisCache.store.mget('{foo}', '{foo}2')).resolves.toStrictEqual([
       value,
       value2,
     ]);
   });
   it('should return null when the key is invalid', () =>
     expect(
-      redisCache.store.mget('invalidKey', 'otherInvalidKey'),
-    ).resolves.toStrictEqual([null, null]));
+      redisCache.store.mget('invalid{Key}', 'otherInvalid{Key}'),
+    ).resolves.toStrictEqual([undefined, undefined]));
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.store.mget('foo')).rejects.toBeDefined();
   });
 });
@@ -186,25 +183,58 @@ describe('del', () => {
 
   it('should delete a unlimited number of keys', async () => {
     await redisCache.store.mset([
-      ['foo', 'bar'],
-      ['foo2', 'bar2'],
+      ['{foo}', 'bar'],
+      ['{foo}2', 'bar2'],
     ]);
     await expect(
-      redisCache.store.del(['foo', 'foo2']),
+      redisCache.store.mdel('{foo}', '{foo}2'),
     ).resolves.toBeUndefined();
   });
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.del('foo')).rejects.toBeDefined();
   });
+
+  it('should delete when key prefix is set', async () => {
+		const keyPrefix = "prefix";
+    const key = "foo77";
+    await redisCache.set(key, "bar");
+    const customConfig = {
+      ...config, 
+      keyPrefix: keyPrefix,
+    };
+    const redisCachePrefix = await caching(
+      redisClusterStore, customConfig
+    );
+    await redisCachePrefix.set(key, "bar");
+    await expect(redisCache.get(`${keyPrefix}:${key}`)).resolves.toEqual("bar");
+    await redisCachePrefix.del(key);
+    await expect(redisCachePrefix.get(key)).resolves.toBeUndefined();
+    expect(redisCache.get(key)).resolves.toEqual("bar");
+
+    await redisCache.store.mset([
+			["{foo}", "bar"],
+			["{foo}2", "bar2"],
+		]);
+		await redisCachePrefix.store.mset([
+			["{foo}", "bar"],
+			["{foo}2", "bar2"],
+		]);
+		await redisCachePrefix.store.mdel("{foo}", "{foo}2");
+		await expect(redisCachePrefix.store.mget("{foo}", "{foo}2")).resolves.toStrictEqual([undefined, undefined]);
+		await expect(redisCache.store.mget("{foo}", "{foo}2")).resolves.toStrictEqual([
+			"bar",
+			"bar2",
+		]);
+	});
 });
 
 describe('reset', () => {
   it('should flush underlying db', () => redisCache.reset());
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.reset()).rejects.toBeDefined();
   });
 });
@@ -213,7 +243,9 @@ describe('ttl', () => {
   it('should retrieve ttl for a given key', async () => {
     const ttl = 100;
     await redisCache.set('foo', 'bar', ttl);
-    await expect(redisCache.store.ttl('foo')).resolves.toEqual(ttl);
+    await expect(redisCache.store.ttl('foo')).resolves.toBeGreaterThanOrEqual(
+			ttl - 10,
+		);
 
     await redisCache.set('foo', 'bar', 0);
     await expect(redisCache.store.ttl('foo')).resolves.toEqual(-1);
@@ -222,8 +254,30 @@ describe('ttl', () => {
   it('should retrieve ttl for an invalid key', () =>
     expect(redisCache.store.ttl('invalidKey')).resolves.toEqual(-2));
 
+  it('should retrieve ttl when key prefix is set', async () => {
+		const ttl = 1000;
+    const keyPrefix = "prefix";
+    const key = "foo77";
+    const customConfig = {
+      ...config, 
+      keyPrefix: keyPrefix,
+    };
+    const redisCachePrefix = await caching(
+      redisClusterStore, customConfig
+    );
+    await redisCachePrefix.set(key, "bar", ttl);
+    await expect(
+      redisCachePrefix.store.ttl(key)
+    ).resolves.toBeGreaterThanOrEqual(ttl - 10);
+    await expect(redisCache.get(key)).resolves.toBeUndefined();
+    expect(redisCache.store.ttl(key)).resolves.toEqual(-2);
+    const key2 = "foo88";
+    await redisCache.set(key2, "bar", 0);
+    await expect(redisCache.store.ttl(key2)).resolves.toEqual(-1);
+	});
+
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.store.ttl('foo')).rejects.toBeDefined();
   });
 });
@@ -236,15 +290,15 @@ describe('keys', () => {
 
   it('should return an array of all keys if called without a pattern', async () => {
     await redisCache.store.mset([
-      ['foo', 'bar'],
-      ['foo2', 'bar2'],
-      ['foo3', 'bar3'],
+      ['{foo}', 'bar'],
+      ['{foo}2', 'bar2'],
+      ['{foo}3', 'bar3'],
     ]);
     await expect(
       redisCache.store
-        .keys('f*')
+        .keys('{f*')
         .then((x) => x.sort((a, b) => a.localeCompare(b))),
-    ).resolves.toStrictEqual(['foo', 'foo2', 'foo3']);
+    ).resolves.toStrictEqual(['{foo}', '{foo}2', '{foo}3']);
   });
 
   it('should return an array of keys without pattern', async () => {
@@ -254,37 +308,37 @@ describe('keys', () => {
   });
 
   it('should return an error if there is an error acquiring a connection', async () => {
-    await redisCache.store.getClient.disconnect();
+    await redisCache.store.client.disconnect();
     await expect(redisCache.store.keys()).rejects.toBeDefined();
   });
 });
 
-describe('isCacheableValue', () => {
+describe('isCacheable', () => {
   it('should return true when the value is not undefined', () => {
-    expect(redisCache.store.isCacheableValue(0)).toBeTruthy();
-    expect(redisCache.store.isCacheableValue(100)).toBeTruthy();
-    expect(redisCache.store.isCacheableValue('')).toBeTruthy();
-    expect(redisCache.store.isCacheableValue('test')).toBeTruthy();
+    expect(redisCache.store.isCacheable(0)).toBeTruthy();
+    expect(redisCache.store.isCacheable(100)).toBeTruthy();
+    expect(redisCache.store.isCacheable('')).toBeTruthy();
+    expect(redisCache.store.isCacheable('test')).toBeTruthy();
   });
 
   it('should return false when the value is undefined', () => {
-    expect(redisCache.store.isCacheableValue(undefined)).toBeFalsy();
+    expect(redisCache.store.isCacheable(undefined)).toBeFalsy();
   });
 
   it('should return false when the value is null', () => {
-    expect(redisCache.store.isCacheableValue(null)).toBeFalsy();
+    expect(redisCache.store.isCacheable(null)).toBeFalsy();
   });
 });
 
 describe('redis error event', () => {
   it('should return an error when the redis server is unavailable', async () => {
     await new Promise<void>((resolve) => {
-      redisCache.store.getClient.on('error', (err) => {
+      redisCache.store.client.on('error', (err) => {
         expect(err).not.toEqual(null);
         resolve();
       });
 
-      redisCache.store.getClient.emit('error', 'Something unexpected');
+      redisCache.store.client.emit('error', 'Something unexpected');
     });
   });
 });


### PR DESCRIPTION
I needed keyPrefix for ttl and for keyPrefix to be available in my editor's type hints when using clusterStore.
What I fixed is listed below, but if you can help me get just those changes out, I'd be grateful (also @jaredwray  let me know if you'd like me to submit a smaller PR with just those few changes if this is too much or not).

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. (All the features I've added or fixed should be covered)
- [] Docs have been added / updated (for bug fixes / features) (I didn't find relevant data in the docs about redis store so I didn't add)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add keyPrefix to mDel, mGet and ttl
Change clusterStore options type to include customOptions to allow for keyPrefix in intellisense Add tests for keyPrefix coverage
Readd the already existing cluster tests file (it didn't get to run before): use {} to avoid CROSSSLOT errors and change the compose file to create a single node cluster for the sake of testing