### PR TITLE
Add `repository.directory` field to each packages' `package.json`

### DIFF
--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jaredwray/cacheable.git"
+    "url": "git+https://github.com/jaredwray/cacheable.git",
+    "directory": "packages/cache-manager"
   },
   "keywords": [
     "cache",

--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf ./dist ./coverage ./node_modules",
     "test": "xo --fix && vitest run --coverage",
-    "test:ci": "xo && vitest run --coverage",
+    "test:ci": "xo && vitest run",
     "build": "rimraf ./dist && tsup src/index.ts --format cjs,esm --dts --clean",
     "prepare": "pnpm run build"
   },

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -55,7 +55,7 @@
 		"@types/node": "^20.14.8",
 		"@types/responselike": "^1.0.3",
 		"@types/sqlite3": "^3.1.11",
-		"@vitest/coverage-v8": "^2.0.5",
+		"@vitest/coverage-v8": "^2.1.2",
 		"body-parser": "^1.20.2",
 		"delay": "^6.0.0",
 		"express": "^4.19.2",
@@ -64,7 +64,7 @@
 		"sqlite3": "^5.1.7",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.5.2",
-		"vitest": "^2.0.5",
+		"vitest": "^2.1.2",
 		"xo": "^0.59.3"
 	},
 	"xo": {

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -3,7 +3,11 @@
 	"version": "12.0.1",
 	"description": "Wrap native HTTP requests with RFC compliant cache support",
 	"license": "MIT",
-	"repository": "jaredwray/cacheable",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jaredwray/cacheable.git",
+		"directory": "packages/cacheable-request"
+    },
 	"author": "Jared Wray <me@jaredwray.com> (http://jaredwray.com)",
 	"type": "module",
 	"exports": "./dist/index.js",

--- a/packages/cacheable/package.json
+++ b/packages/cacheable/package.json
@@ -12,7 +12,11 @@
 			"import": "./dist/index.js"
 		}
 	},
-	"repository": "https://github.com/jaredwray/cacheable.git",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jaredwray/cacheable.git",
+		"directory": "packages/cacheable"
+	},
 	"author": "Jared Wray <me@jaredwray.com>",
 	"license": "MIT",
 	"private": false,

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disabe @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {Keyv, type KeyvStoreAdapter} from 'keyv';
 import {Hookified} from 'hookified';
 import {shorthandToMilliseconds} from './shorthand-time.js';

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -301,7 +301,7 @@ export class Cacheable extends Hookified {
 		let result = false;
 		const promises = [];
 		if (this.stats.enabled) {
-			const statResult = await this._primary.get<object>(key);
+			const statResult = await this._primary.get<Record<string, unknown>>(key);
 			if (statResult) {
 				this.stats.decreaseKSize(key);
 				this.stats.decreaseVSize(statResult);

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -301,7 +301,7 @@ export class Cacheable extends Hookified {
 		let result = false;
 		const promises = [];
 		if (this.stats.enabled) {
-			const statResult = await this._primary.get(key);
+			const statResult = await this._primary.get<object>(key);
 			if (statResult) {
 				this.stats.decreaseKSize(key);
 				this.stats.decreaseVSize(statResult);

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disabe @typescript-eslint/no-unsafe-assignment */
 import {Keyv, type KeyvStoreAdapter} from 'keyv';
 import {Hookified} from 'hookified';
 import {shorthandToMilliseconds} from './shorthand-time.js';

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {Keyv, type KeyvStoreAdapter} from 'keyv';
 import {Hookified} from 'hookified';
 import {shorthandToMilliseconds} from './shorthand-time.js';
@@ -328,7 +327,7 @@ export class Cacheable extends Hookified {
 
 	public async deleteMany(keys: string[]): Promise<boolean> {
 		if (this.stats.enabled) {
-			const statResult = await this._primary.get(keys);
+			const statResult = await this._primary.get(keys) as unknown;
 			for (const key of keys) {
 				this.stats.decreaseKSize(key);
 				this.stats.decreaseVSize(statResult);

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -288,7 +288,7 @@ describe('cacheable get method', async () => {
 		expect(secondaryResult).toEqual(['value1', 'value2']);
 		const result = await cacheable.getMany(['key1', 'key2']);
 		expect(result).toEqual(['value1', 'value2']);
-		const primaryResult = await cacheable.primary.get('key1');
+		const primaryResult = await cacheable.primary.get<string>('key1');
 		expect(primaryResult).toEqual('value1');
 	});
 });

--- a/packages/cacheable/test/keyv-memory.test.ts
+++ b/packages/cacheable/test/keyv-memory.test.ts
@@ -18,14 +18,14 @@ describe('Keyv Cacheable Memory', () => {
 	test('should get undefined from keyv cacheable memory', async () => {
 		const keyvCacheableMemory = new KeyvCacheableMemory();
 		const keyv = new Keyv({store: keyvCacheableMemory});
-		const value = await keyv.get('key');
+		const value = await keyv.get('key') as string | undefined;
 		expect(value).toBe(undefined);
 	});
 	test('should set and get value from keyv cacheable memory', async () => {
 		const keyvCacheableMemory = new KeyvCacheableMemory();
 		const keyv = new Keyv({store: keyvCacheableMemory});
 		await keyv.set('key', 'value');
-		const value = await keyv.get('key');
+		const value = await keyv.get<string>('key');
 		expect(value).toBe('value');
 	});
 	test('should delete value from keyv cacheable memory', async () => {
@@ -33,7 +33,7 @@ describe('Keyv Cacheable Memory', () => {
 		const keyv = new Keyv({store: keyvCacheableMemory});
 		await keyv.set('key', 'value');
 		await keyv.delete('key');
-		const value = await keyv.get('key');
+		const value = await keyv.get<string>('key');
 		expect(value).toBe(undefined);
 	});
 	test('should clear keyv cacheable memory', async () => {
@@ -41,7 +41,7 @@ describe('Keyv Cacheable Memory', () => {
 		const keyv = new Keyv({store: keyvCacheableMemory});
 		await keyv.set('key', 'value');
 		await keyv.clear();
-		const value = await keyv.get('key');
+		const value = await keyv.get<string>('key');
 		expect(value).toBe(undefined);
 	});
 	test('should check if key exists in keyv cacheable memory', async () => {
@@ -63,7 +63,7 @@ describe('Keyv Cacheable Memory', () => {
 		const keyv = new Keyv({store: keyvCacheableMemory});
 		await keyv.set('key', 'value');
 		await keyv.delete(['key']);
-		const value = await keyv.get('key');
+		const value = await keyv.get<string>('key');
 		expect(value).toBe(undefined);
 	});
 	test('should set many values in keyv cacheable memory', async () => {

--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -12,7 +12,11 @@
 			"import": "./dist/index.js"
 		}
 	},
-	"repository": "https://github.com/jaredwray/cacheable.git",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jaredwray/cacheable.git",
+		"directory": "packages/file-entry-cache"
+	},
 	"author": "Jared Wray <me@jaredwray.com>",
 	"license": "MIT",
 	"private": false,

--- a/packages/flat-cache/package.json
+++ b/packages/flat-cache/package.json
@@ -12,7 +12,11 @@
 			"import": "./dist/index.js"
 		}
 	},
-	"repository": "https://github.com/jaredwray/cacheable.git",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jaredwray/cacheable.git",
+		"directory": "packages/flat-cache"
+	},
 	"author": "Jared Wray <me@jaredwray.com>",
 	"license": "MIT",
 	"private": false,

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -12,7 +12,11 @@
 			"import": "./dist/index.js"
 		}
 	},
-	"repository": "https://github.com/jaredwray/cacheable.git",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/jaredwray/cacheable.git",
+		"directory": "packages/node-cache"
+	},
 	"author": "Jared Wray <me@jaredwray.com>",
 	"license": "MIT",
 	"private": false,


### PR DESCRIPTION
The field has been supported, see <https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository>.

Adding the field will make the `npm repo` command more useful. E.g.

With the field:

```sh-session
$ npm repo vitest --no-browser
vitest repo available at the following URL:
https://github.com/vitest-dev/vitest/tree/HEAD/packages/vitest
```

Without the field:

```sh-session
$ npm repo cacheable --no-browser
cacheable repo available at the following URL:
https://github.com/jaredwray/cacheable
```

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature
