### PR TITLE
Cacheable request  - upgrading to keyv v5 (BREAKING CHANGE)

### DIFF
--- a/packages/cacheable-request/README.md
+++ b/packages/cacheable-request/README.md
@@ -130,7 +130,11 @@ npm install @keyv/redis
 And then you can pass `CacheableRequest` your connection string:
 
 ```js
-const cacheableRequest = new CacheableRequest(http.request, 'redis://user:pass@localhost:6379').createCacheableRequest();
+import KeyvRedis from '@keyv/redis';
+import CacheableRequest from 'cacheable-request';
+
+const keyvRedis = new KeyvRedis('redis://localhost:6379');
+const cacheableRequest = new CacheableRequest(http.request, KeyvRedis).createCacheableRequest();
 ```
 
 [View all official Keyv storage adapters.](https://github.com/jaredwray/keyv#official-storage-adapters)

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -45,7 +45,7 @@
 		"@types/http-cache-semantics": "^4.0.4",
 		"get-stream": "^9.0.1",
 		"http-cache-semantics": "^4.1.1",
-		"keyv": "^5.1.1",
+		"keyv": "^5.1.2",
 		"mimic-response": "^4.0.0",
 		"normalize-url": "^8.0.1",
 		"responselike": "^3.0.0"

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -45,13 +45,13 @@
 		"@types/http-cache-semantics": "^4.0.4",
 		"get-stream": "^9.0.1",
 		"http-cache-semantics": "^4.1.1",
-		"keyv": "^4.5.4",
+		"keyv": "^5.1.1",
 		"mimic-response": "^4.0.0",
 		"normalize-url": "^8.0.1",
 		"responselike": "^3.0.0"
 	},
 	"devDependencies": {
-		"@keyv/sqlite": "^3.6.7",
+		"@keyv/sqlite": "^4.0.1",
 		"@types/node": "^22.7.7",
 		"@types/responselike": "^1.0.3",
 		"@types/sqlite3": "^3.1.11",

--- a/packages/cacheable-request/src/index.ts
+++ b/packages/cacheable-request/src/index.ts
@@ -3,11 +3,12 @@ import urlLib from 'node:url';
 import crypto from 'node:crypto';
 import stream, {PassThrough as PassThroughStream} from 'node:stream';
 import {IncomingMessage} from 'node:http';
+import process from 'node:process';
 import normalizeUrl from 'normalize-url';
 import {getStreamAsBuffer} from 'get-stream';
 import CachePolicy from 'http-cache-semantics';
 import Response from 'responselike';
-import {Keyv, type KeyvStoreAdapter} from 'keyv';
+import {Keyv} from 'keyv';
 import mimicResponse from 'mimic-response';
 import {
 	RequestFn, CacheResponse, CacheValue, CacheableOptions, UrlOption, CacheError, RequestError, Emitter, CacheableRequestFunction,

--- a/packages/cacheable-request/src/index.ts
+++ b/packages/cacheable-request/src/index.ts
@@ -23,13 +23,8 @@ class CacheableRequest {
 	constructor(cacheRequest: RequestFn, cacheAdapter?: any) {
 		if (cacheAdapter instanceof Keyv) {
 			this.cache = cacheAdapter;
-		} else if (cacheAdapter instanceof Map) {
-			this.cache = new Keyv<any>({
-				store: cacheAdapter,
-				namespace: 'cacheable-request',
-			});
 		} else {
-			this.cache = new Keyv<any>({
+			this.cache = new Keyv({
 				store: cacheAdapter,
 				namespace: 'cacheable-request',
 			});

--- a/packages/cacheable-request/src/index.ts
+++ b/packages/cacheable-request/src/index.ts
@@ -21,13 +21,15 @@ class CacheableRequest {
 	cacheRequest: RequestFn;
 	hooks: Map<string, Function_> = new Map<string, Function_>();
 	constructor(cacheRequest: RequestFn, cacheAdapter?: any) {
-		if (cacheAdapter instanceof Keyv) {
-			this.cache = cacheAdapter;
-		} else {
-			this.cache = new Keyv({
-				store: cacheAdapter,
-				namespace: 'cacheable-request',
-			});
+		if (cacheAdapter) {
+			if (cacheAdapter instanceof Keyv) {
+				this.cache = cacheAdapter;
+			} else {
+				this.cache = new Keyv({
+					store: cacheAdapter,
+					namespace: 'cacheable-request',
+				});
+			}
 		}
 
 		this.request = this.request.bind(this);

--- a/packages/cacheable-request/src/types.ts
+++ b/packages/cacheable-request/src/types.ts
@@ -13,7 +13,6 @@ import {
 import {URL} from 'node:url';
 import {EventEmitter} from 'node:events';
 import {Buffer} from 'node:buffer';
-import {Store} from 'keyv';
 import ResponseLike from 'responselike';
 import {CachePolicyObject} from 'http-cache-semantics';
 
@@ -28,8 +27,6 @@ export type CacheableRequestFunction = (
 ) => Emitter;
 
 export type CacheableOptions = Options & RequestOptions | string | URL;
-
-export type StorageAdapter = Store<any>;
 
 export interface Options {
 	/**

--- a/packages/cacheable-request/src/types.ts
+++ b/packages/cacheable-request/src/types.ts
@@ -136,6 +136,7 @@ export class RequestError extends Error {
 		Object.defineProperties(this, Object.getOwnPropertyDescriptors(error));
 	}
 }
+
 export class CacheError extends Error {
 	constructor(error: Error) {
 		super(error.message);

--- a/packages/cacheable-request/test/cache.test.ts
+++ b/packages/cacheable-request/test/cache.test.ts
@@ -582,26 +582,6 @@ test('Custom Keyv instance adapters used', async () => {
 	const cached = await cache.get(`GET:${s.url + endpoint}`);
 	expect(response.body).toBe(cached.body.toString());
 });
-test('Keyv cache adapters load via connection uri', async () => {
-	const endpoint = '/cache';
-	const cacheableRequest = new CacheableRequest(
-		request,
-		'sqlite://test/testdb.sqlite',
-	);
-	const cacheableRequestHelper = promisify(cacheableRequest.request());
-	const database = new sqlite3.Database('test/testdb.sqlite');
-	const firstResponse: any = await cacheableRequestHelper(s.url + endpoint);
-	await delay(1000);
-	const secondResponse: any = await cacheableRequestHelper(s.url + endpoint);
-	database.all(`SELECT * FROM keyv WHERE "key" = "cacheable-request:GET:${
-		s.url + endpoint
-	}"`, (error, data) => {
-		expect(data.length).toBe(1);
-		database.all('DELETE FROM keyv');
-	});
-	expect(firstResponse.fromCache).toBeFalsy();
-	expect(secondResponse.fromCache).toBeTruthy();
-});
 test('ability to force refresh', async () => {
 	const endpoint = '/cache';
 	const cache = new Map();

--- a/packages/cacheable-request/test/cache.test.ts
+++ b/packages/cacheable-request/test/cache.test.ts
@@ -8,7 +8,7 @@ import {
 import getStream from 'get-stream';
 import delay from 'delay';
 import sqlite3 from 'sqlite3';
-import Keyv from 'keyv';
+import {Keyv} from 'keyv';
 import CacheableRequest, {CacheValue, onResponse} from '../src/index.js';
 import createTestServer from './create-test-server/index.mjs';
 

--- a/packages/cacheable-request/test/cache.test.ts
+++ b/packages/cacheable-request/test/cache.test.ts
@@ -7,7 +7,6 @@ import {
 } from 'vitest';
 import getStream from 'get-stream';
 import delay from 'delay';
-import sqlite3 from 'sqlite3';
 import {Keyv} from 'keyv';
 import CacheableRequest, {CacheValue, onResponse} from '../src/index.js';
 import createTestServer from './create-test-server/index.mjs';
@@ -338,6 +337,7 @@ test(
 test('auth should be in url', async () => testCacheKey({auth: 'user:pass'}, 'GET:http://user:pass@localhost'));
 
 test('should return default url', async () => testCacheKey({method: 'POST'}, 'POST:http://localhost'));
+
 test('request options path query is passed through', async () => {
 	const cacheableRequest = new CacheableRequest(request);
 	const cacheableRequestHelper = promisify(cacheableRequest.request());
@@ -363,6 +363,7 @@ test('request options path query is passed through', async () => {
 		expect(body.query.foo).toBe('bar');
 	}
 });
+
 test('Setting opts.cache to false bypasses cache for a single request', async () => {
 	const endpoint = '/cache';
 	const cache = new Map();

--- a/packages/cacheable-request/test/cacheable-request-class.test.ts
+++ b/packages/cacheable-request/test/cacheable-request-class.test.ts
@@ -1,6 +1,6 @@
 import {request} from 'node:http';
 import {test, expect} from 'vitest';
-import Keyv from 'keyv';
+import {Keyv} from 'keyv';
 import CacheableRequest from '../src/index.js';
 
 test('CacheableRequest is a function', () => {

--- a/packages/cacheable-request/test/cacheable-request-instance.test.ts
+++ b/packages/cacheable-request/test/cacheable-request-instance.test.ts
@@ -6,6 +6,7 @@ import {
 	test, expect, beforeAll, afterAll,
 } from 'vitest';
 import getStream from 'get-stream';
+import {KeyvSqlite} from '@keyv/sqlite';
 import CacheableRequest from '../src/index.js';
 import {CacheError, RequestError} from '../src/types.js';
 import createTestServer from './create-test-server/index.mjs';
@@ -87,7 +88,7 @@ test('cacheableRequest emits response event for cached responses', () => {
 	}).on('request', (request_: any) => request_.end());
 });
 test('cacheableRequest emits CacheError if cache adapter connection errors', () => {
-	const cacheableRequest = new CacheableRequest(request, 'sqlite://non/existent/database.sqlite').request();
+	const cacheableRequest = new CacheableRequest(request, new KeyvSqlite('sqlite://non/existent/database.sqlite')).request();
 	cacheableRequest(url.parse(s.url))
 		.on('error', (error: any) => {
 			expect(error instanceof CacheError).toBeTruthy();
@@ -177,7 +178,8 @@ test('cacheableRequest emits RequestError if request function throws', () => {
 	options.headers = {invalid: '💣'};
 	cacheableRequest(options)
 		.on('error', (error: any) => {
-			expect(error instanceof RequestError).toBeTruthy();
+			console.log(error);
+			expect(error).toBeTruthy();
 		})
 		.on('request', (request_: any) => request_.end());
 });
@@ -245,7 +247,7 @@ test('cacheableRequest does not cache response if request is aborted after recei
 	/* eslint-enable max-nested-callbacks */
 });
 test('cacheableRequest makes request even if initial DB connection fails (when opts.automaticFailover is enabled)', async () => {
-	const cacheableRequest = new CacheableRequest(request, 'sqlite://non/existent/database.sqlite').request();
+	const cacheableRequest = new CacheableRequest(request, new KeyvSqlite('sqlite://non/existent/database.sqlite')).request();
 	const options: any = url.parse(s.url);
 	options.automaticFailover = true;
 	cacheableRequest(options, (response_: any) => {

--- a/packages/cacheable-request/test/cacheable-request-instance.test.ts
+++ b/packages/cacheable-request/test/cacheable-request-instance.test.ts
@@ -172,14 +172,13 @@ test('cacheableRequest emits CacheError if cache.delete errors', () => {
 		}).on('request', (request_: any) => request_.end());
 	})();
 });
-test('cacheableRequest emits RequestError if request function throws', () => {
+test('cacheableRequest emits Error if request function throws', () => {
 	const cacheableRequest = new CacheableRequest(request).request();
 	const options: any = url.parse(s.url);
 	options.headers = {invalid: '💣'};
 	cacheableRequest(options)
 		.on('error', (error: any) => {
-			console.log(error);
-			expect(error).toBeTruthy();
+			expect(error instanceof RequestError).toBeTruthy();
 		})
 		.on('request', (request_: any) => request_.end());
 });

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -49,7 +49,7 @@
 	"dependencies": {
 		"cacheable": "^1.7.0",
 		"eventemitter3": "^5.0.1",
-		"keyv": "^5.1.0"
+		"keyv": "^5.1.1"
 	},
 	"files": [
 		"dist",

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -49,7 +49,7 @@
 	"dependencies": {
 		"cacheable": "^1.7.0",
 		"eventemitter3": "^5.0.1",
-		"keyv": "^5.1.1"
+		"keyv": "^5.1.2"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This will no longer support a string uri for the adapter. You have to specifically add in Keyv or a KeyvStorageAdapter 