### PR TITLE
Cacheable - fixing the wrap function to use the key as a prefix

### DIFF
--- a/packages/cacheable/README.md
+++ b/packages/cacheable/README.md
@@ -298,11 +298,15 @@ By default we use lazy expiration deletion which means on `get` and `getMany` ty
 ```javascript
 import { Cacheable } from 'cacheable';
 const asyncFunction = async (value: number) => {
-  return value * 2;
+  return Math.random() * value;
 };
 
 const cache = new Cacheable();
-const wrappedFunction = cache.wrap(asyncFunction, { ttl: '1h' });
+const options = {
+  ttl: '1h', // 1 hour
+  key: 'asyncFunctionKey' // used for prefixing the wrapped function
+}
+const wrappedFunction = cache.wrap(asyncFunction, options);
 console.log(await wrappedFunction(2)); // 4
 console.log(await wrappedFunction(2)); // 4 from cache
 ```

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -5,7 +5,7 @@ import {KeyvCacheableMemory} from './keyv-memory.js';
 import {CacheableStats} from './stats.js';
 import {type CacheableItem} from './cacheable-item-types.js';
 import {hash} from './hash.js';
-import {wrap} from './wrap.js';
+import {wrap, wrapKey, type WrapFunctionOptions} from './wrap.js';
 
 export enum CacheableHooks {
 	BEFORE_SET = 'BEFORE_SET',
@@ -568,7 +568,7 @@ export class Cacheable extends Hookified {
 	 * @param {WrapOptions} [options] The options for the wrap function
 	 * @returns {Function} The wrapped function
 	 */
-	public wrap<T>(function_: (...arguments_: any[]) => T, options: {ttl?: number; key?: string} = {}): (...arguments_: any[]) => T {
+	public wrap<T>(function_: (...arguments_: any[]) => T, options: WrapFunctionOptions): (...arguments_: any[]) => T {
 		const wrapOptions = {
 			ttl: options.ttl,
 			key: options.key,
@@ -576,6 +576,16 @@ export class Cacheable extends Hookified {
 		};
 
 		return wrap<T>(function_, wrapOptions);
+	}
+
+	/**
+	 * Will create the key for the function with a prefix (internal use)
+	 * @param function_ - arguments to hash
+	 * @param {string} key - the key to prefix
+	 * @returns {string} - The wrap key used in cache
+	 */
+	public wrapKey(function_: (...arguments_: any[]) => any, key: string): string {
+		return wrapKey(function_, key);
 	}
 
 	/**

--- a/packages/cacheable/src/memory.ts
+++ b/packages/cacheable/src/memory.ts
@@ -1,4 +1,4 @@
-import {wrapSync} from './wrap.js';
+import {wrapSync, wrapKey, type WrapFunctionOptions} from './wrap.js';
 import {DoublyLinkedList} from './memory-lru.js';
 import {shorthandToTime} from './shorthand-time.js';
 import {type CacheableStoreItem, type CacheableItem} from './cacheable-item-types.js';
@@ -477,7 +477,7 @@ export class CacheableMemory {
 	 * @param {Object} [options] - The options to wrap
 	 * @returns {Function} - The wrapped function
 	 */
-	public wrap<T>(function_: (...arguments_: any[]) => T, options: {ttl?: number; key?: string} = {}): (...arguments_: any[]) => T {
+	public wrap<T>(function_: (...arguments_: any[]) => T, options: WrapFunctionOptions): (...arguments_: any[]) => T {
 		const wrapOptions = {
 			ttl: options.ttl,
 			key: options.key,
@@ -485,6 +485,16 @@ export class CacheableMemory {
 		};
 
 		return wrapSync<T>(function_, wrapOptions);
+	}
+
+	/**
+	 * Will create the key for the function with a prefix (internal use)
+	 * @param function_ - arguments to hash
+	 * @param {string} key - the key to prefix
+	 * @returns {string} - The wrap key used in cache
+	 */
+	public wrapKey(function_: (...arguments_: any[]) => any, key: string): string {
+		return wrapKey(function_, key);
 	}
 
 	private isPrimitive(value: any): boolean {

--- a/packages/cacheable/src/wrap.ts
+++ b/packages/cacheable/src/wrap.ts
@@ -2,14 +2,19 @@ import {type Cacheable, type CacheableMemory} from './index.js';
 
 export type WrapOptions = {
 	ttl?: number | string;
-	key?: string;
+	key: string;
 	cache: Cacheable;
 };
 
 export type WrapSyncOptions = {
 	ttl?: number | string;
-	key?: string;
+	key: string;
 	cache: CacheableMemory;
+};
+
+export type WrapFunctionOptions = {
+	ttl?: number | string;
+	key: string;
 };
 
 export type AnyFunction = (...arguments_: any[]) => any;
@@ -18,7 +23,7 @@ export function wrapSync<T>(function_: AnyFunction, options: WrapSyncOptions): A
 	const {ttl, key, cache} = options;
 
 	return function (...arguments_: any[]) {
-		const cacheKey = key ?? cache.hash(arguments_);
+		const cacheKey = wrapKey(function_, key);
 
 		let value = cache.get(cacheKey);
 
@@ -37,7 +42,7 @@ export function wrap<T>(function_: AnyFunction, options: WrapOptions): AnyFuncti
 	const {ttl, key, cache} = options;
 
 	return async function (...arguments_: any[]) {
-		const cacheKey = key ?? cache.hash(arguments_);
+		const cacheKey = wrapKey(function_, key);
 
 		let value = await cache.get(cacheKey) as T | undefined;
 
@@ -50,4 +55,8 @@ export function wrap<T>(function_: AnyFunction, options: WrapOptions): AnyFuncti
 
 		return value;
 	};
+}
+
+export function wrapKey(function_: AnyFunction, key: string): string {
+	return `${key}::${function_.name}`;
 }

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -621,6 +621,25 @@ describe('cacheable wrap', async () => {
 		const cacheResult2 = await cacheable.get(cacheKey);
 		expect(cacheResult2).toBeUndefined();
 	});
+	test('wrap async function', async () => {
+		const cache = new Cacheable();
+		const options = {
+			key: 'cacheKey',
+			ttl: '5m',
+		};
+
+		const plus = async (a: number, b: number) => a + b;
+		const plusCached = cache.wrap(plus, options);
+
+		const multiply = async (a: number, b: number) => a * b;
+		const multiplyCached = cache.wrap(multiply, options);
+
+		const result1 = await plusCached(1, 2);
+		const result2 = await multiplyCached(1, 2);
+
+		expect(result1).toBe(3);
+		expect(result2).toBe(2);
+	});
 });
 
 describe('cacheable namespace', async () => {

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -614,10 +614,11 @@ describe('cacheable wrap', async () => {
 		const result = await wrapped(1);
 		const result2 = await wrapped(1);
 		expect(result).toBe(result2);
-		const cacheResult1 = await cacheable.get('cacheKey');
+		const cacheKey = cacheable.wrapKey(asyncFunction, 'cacheKey');
+		const cacheResult1 = await cacheable.get(cacheKey);
 		expect(cacheResult1).toBe(result);
 		await sleep(20);
-		const cacheResult2 = await cacheable.get('cacheKey');
+		const cacheResult2 = await cacheable.get(cacheKey);
 		expect(cacheResult2).toBeUndefined();
 	});
 });

--- a/packages/cacheable/test/memory.test.ts
+++ b/packages/cacheable/test/memory.test.ts
@@ -444,10 +444,11 @@ describe('cacheable wrap', async () => {
 		const result = wrapped(1);
 		const result2 = wrapped(1);
 		expect(result).toBe(result2);
-		const cacheResult1 = cacheable.get<number>('cacheKey');
+		const cacheKey = cacheable.wrapKey(syncFunction, 'cacheKey');
+		const cacheResult1 = cacheable.get<number>(cacheKey);
 		expect(cacheResult1).toBe(result);
 		await sleep(20);
-		const cacheResult2 = cacheable.get<number>('cacheKey');
+		const cacheResult2 = cacheable.get<number>(cacheKey);
 		expect(cacheResult2).toBeUndefined();
 	});
 });

--- a/packages/cacheable/test/wrap.test.ts
+++ b/packages/cacheable/test/wrap.test.ts
@@ -4,7 +4,7 @@ import {
 } from 'vitest';
 import {Cacheable, CacheableMemory} from '../src/index.js';
 import {
-	wrap, wrapSync, type WrapOptions, type WrapSyncOptions,
+	wrap, wrapKey, wrapSync, type WrapOptions, type WrapSyncOptions,
 } from '../src/wrap.js';
 import {sleep} from './sleep.js';
 
@@ -26,7 +26,8 @@ describe('wrap function', () => {
 
 		// Expectations
 		expect(result).toBe(3);
-		const cacheResult = await cache.get('cacheKey');
+		const cacheKey = wrapKey(asyncFunction, options.key);
+		const cacheResult = await cache.get(cacheKey);
 		expect(cacheResult).toBe(3);
 	});
 
@@ -36,6 +37,7 @@ describe('wrap function', () => {
 		const cache = new Cacheable();
 
 		const options: WrapOptions = {
+			key: 'cacheKey',
 			cache,
 		};
 
@@ -67,7 +69,8 @@ describe('wrap function', () => {
 
 		// Expectations
 		expect(result).toBe(result2);
-		const cacheResult = cache.get('cacheKey');
+		const cacheKey = wrapKey(syncFunction, options.key);
+		const cacheResult = cache.get(cacheKey);
 		expect(cacheResult).toBe(result);
 	});
 
@@ -76,6 +79,7 @@ describe('wrap function', () => {
 		const syncFunction = (value: number) => Math.random() * value;
 		const cache = new CacheableMemory();
 		const options: WrapSyncOptions = {
+			key: 'cacheKey',
 			cache,
 		};
 
@@ -110,7 +114,8 @@ describe('wrap function', () => {
 		// Expectations
 		expect(result).toBe(result2);
 		await sleep(30);
-		const cacheResult = cache.get('cacheKey');
+		const cacheKey = wrapKey(syncFunction, options.key);
+		const cacheResult = cache.get(cacheKey);
 		expect(cacheResult).toBe(undefined);
 	});
 
@@ -119,6 +124,7 @@ describe('wrap function', () => {
 		const syncFunction = (value: number, person: {first: string; last: string; meta: any}) => Math.random() * value;
 		const cache = new CacheableMemory();
 		const options: WrapSyncOptions = {
+			key: 'cacheKey',
 			cache,
 		};
 
@@ -153,7 +159,8 @@ describe('wrap function', () => {
 		// Expectations
 		expect(result).toBe(result2);
 		await sleep(1500);
-		const cacheResult = cache.get('cacheKey');
+		const cacheKey = wrapKey(syncFunction, options.key);
+		const cacheResult = cache.get(cacheKey);
 		expect(cacheResult).toBe(undefined);
 	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Cacheable - fixing the wrap function to use the key as a prefix fir #861 

@edwdch - thanks and it was a mistake as the key is the prefix and is now required. 