### PR TITLE
file-entry-cache - upgrading flat-cache to 6.1.2

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -45,7 +45,7 @@
 		"xo": "^0.59.3"
 	},
 	"dependencies": {
-		"flat-cache": "^6.1.1"
+		"flat-cache": "^6.1.2"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - upgrading flat-cache to 6.1.2