### PR TITLE
file-entry-cache - upgrading vitest to 2.1.4

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -36,12 +36,12 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"devDependencies": {
-		"@types/node": "^22.8.1",
-		"@vitest/coverage-v8": "^2.1.3",
+		"@types/node": "^22.9.0",
+		"@vitest/coverage-v8": "^2.1.4",
 		"rimraf": "^6.0.1",
 		"tsup": "^8.3.5",
 		"typescript": "^5.6.3",
-		"vitest": "^2.1.3",
+		"vitest": "^2.1.4",
 		"xo": "^0.59.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - upgrading vitest to 2.1.4