### PR TITLE
file-entry-cache - upgrading vitest to 2.1.5

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -36,12 +36,12 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"devDependencies": {
-		"@types/node": "^22.9.0",
-		"@vitest/coverage-v8": "^2.1.4",
+		"@types/node": "^22.9.3",
+		"@vitest/coverage-v8": "^2.1.5",
 		"rimraf": "^6.0.1",
 		"tsup": "^8.3.5",
-		"typescript": "^5.6.3",
-		"vitest": "^2.1.4",
+		"typescript": "^5.7.2",
+		"vitest": "^2.1.5",
 		"xo": "^0.59.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - upgrading vitest to 2.1.5