### PR TITLE
file-entry-cache - changed does not get set on meta.data changes

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-entry-cache",
-	"version": "10.0.3",
+	"version": "10.0.4",
 	"description": "A lightweight cache for file metadata, ideal for processes that work on a specific set of files and only need to reprocess files that have changed since the last run",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/file-entry-cache/src/index.ts
+++ b/packages/file-entry-cache/src/index.ts
@@ -290,10 +290,6 @@ export class FileEntryCache {
 			return result;
 		}
 
-		if (result.meta.data !== metaCache.data) {
-			result.changed = true;
-		}
-
 		// Set the data from the cache
 		if (result.meta.data === undefined) {
 			result.meta.data = metaCache.data;

--- a/packages/file-entry-cache/test/index.test.ts
+++ b/packages/file-entry-cache/test/index.test.ts
@@ -188,7 +188,7 @@ describe('getFileDescriptor()', () => {
 		const fileDescriptor4 = fileEntryCache3.getFileDescriptor(testFile1);
 		expect(fileDescriptor4).toBeDefined();
 		expect(fileDescriptor4.meta.data).toEqual(data2);
-		expect(fileDescriptor4.changed).toEqual(true);
+		expect(fileDescriptor4.changed).toEqual(false);
 	});
 
 	test('should return a file descriptor', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - changed does not get set on meta.data changes