### PR TITLE
node-cache - moving to hookified instead of eventemitter3

### DIFF
--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"cacheable": "^1.8.1",
-		"eventemitter3": "^5.0.1",
+		"hookified": "^1.5.1",
 		"keyv": "^5.2.1"
 	},
 	"files": [

--- a/packages/node-cache/src/index.ts
+++ b/packages/node-cache/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import eventemitter from 'eventemitter3';
 import {CacheableMemory, CacheableStats, shorthandToTime} from 'cacheable';
+import { Hookified } from 'hookified';
 
 export type NodeCacheOptions = {
 	/**
@@ -71,7 +71,7 @@ export type NodeCacheStats = {
 	vsize: number;
 };
 
-export default class NodeCache extends eventemitter {
+export default class NodeCache extends Hookified {
 	public readonly options: NodeCacheOptions = {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		stdTTL: 0,

--- a/packages/node-cache/src/index.ts
+++ b/packages/node-cache/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {CacheableMemory, CacheableStats, shorthandToTime} from 'cacheable';
-import { Hookified } from 'hookified';
+import {Hookified} from 'hookified';
 
 export type NodeCacheOptions = {
 	/**

--- a/packages/node-cache/src/store.ts
+++ b/packages/node-cache/src/store.ts
@@ -1,7 +1,7 @@
 import {Cacheable, CacheableMemory, type CacheableItem} from 'cacheable';
 import {Keyv} from 'keyv';
 import {type NodeCacheItem} from 'index.js';
-import { Hookified } from 'hookified';
+import {Hookified} from 'hookified';
 
 export type NodeCacheStoreOptions = {
 	/**
@@ -48,11 +48,11 @@ export class NodeCacheStore extends Hookified {
 			}
 		}
 
-		// hook up the cacheable events
+		// Hook up the cacheable events
 		this._cache.on('error', (error: Error) => {
+			/* c8 ignore next 1 */
 			this.emit('error', error);
 		});
-
 	}
 
 	/**

--- a/packages/node-cache/src/store.ts
+++ b/packages/node-cache/src/store.ts
@@ -1,6 +1,7 @@
 import {Cacheable, CacheableMemory, type CacheableItem} from 'cacheable';
 import {Keyv} from 'keyv';
 import {type NodeCacheItem} from 'index.js';
+import { Hookified } from 'hookified';
 
 export type NodeCacheStoreOptions = {
 	/**
@@ -27,10 +28,11 @@ export type NodeCacheStoreOptions = {
 	stats?: boolean;
 };
 
-export class NodeCacheStore {
+export class NodeCacheStore extends Hookified {
 	private _maxKeys = 0;
 	private readonly _cache = new Cacheable({primary: new Keyv({store: new CacheableMemory()})});
 	constructor(options?: NodeCacheStoreOptions) {
+		super();
 		if (options) {
 			const cacheOptions = {
 				ttl: options.ttl,
@@ -45,6 +47,12 @@ export class NodeCacheStore {
 				this._maxKeys = options.maxKeys;
 			}
 		}
+
+		// hook up the cacheable events
+		this._cache.on('error', (error: Error) => {
+			this.emit('error', error);
+		});
+
 	}
 
 	/**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
node-cache - moving to hookified instead of eventemitter3