### PR TITLE
cacheable - unref check interval to allow node exit

### DIFF
--- a/packages/cacheable/src/memory.ts
+++ b/packages/cacheable/src/memory.ts
@@ -537,9 +537,15 @@ export class CacheableMemory extends Hookified {
 	 */
 	public startIntervalCheck() {
 		if (this._checkInterval > 0) {
+			if (this._interval) {
+				// Be overly cautious and clear the interval as we've unref'd it
+				// and we don't want to leak it
+				clearInterval(this._interval);
+			}
+
 			this._interval = setInterval(() => {
 				this.checkExpiration();
-			}, this._checkInterval);
+			}, this._checkInterval).unref();
 		}
 	}
 


### PR DESCRIPTION
When a check interval is passed to the cache, cachable starts an interval that prevents node from exiting unless it gets cleared. There is a public method to stop the interval, but it's flagged as internal use only.

Given this, I've opted to unref the interval to allow the node process to exit cleanly.

The other alternative would be to add a public close/disconnect API method -- the Keyv interface seems to account for this case -- however, it does make the API more cumbersome for the end-user.