### PR TITLE
cache-manager - add named return type to createCache

### DIFF
--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -14,6 +14,7 @@ export type CreateCacheOptions = {
 };
 
 export type Cache = {
+	// eslint-disable-next-line @typescript-eslint/ban-types
 	get: <T>(key: string) => Promise<T | null>;
 	mget: <T>(keys: string[]) => Promise<[T]>;
 	set: <T>(key: string, value: T, ttl?: number) => Promise<T>;

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -14,40 +14,40 @@ export type CreateCacheOptions = {
 };
 
 export type Cache = {
-  get: <T>(key: string) => Promise<T | null>;
-  mget: <T>(keys: string[]) => Promise<[T]>;
-  set: <T>(key: string, value: T, ttl?: number) => Promise<T>;
-  mset: <T>(
-    list: Array<{
-      key: string;
-      value: T;
-      ttl?: number;
-    }>
-  ) => Promise<
-    {
-      key: string;
-      value: T;
-      ttl?: number;
-    }[]
-  >;
-  del: (key: string) => Promise<boolean>;
-  mdel: (keys: string[]) => Promise<boolean>;
-  clear: () => Promise<boolean>;
-  wrap: <T>(
-    key: string,
-    fnc: () => T | Promise<T>,
-    ttl?: number | ((value: T) => number),
-    refreshThreshold?: number
-  ) => Promise<T>;
-  on: <E extends keyof Events>(
-    event: E,
-    listener: Events[E]
-  ) => EventEmitter<[never]>;
-  off: <E extends keyof Events>(
-    event: E,
-    listener: Events[E]
-  ) => EventEmitter<[never]>;
-  disconnect: () => Promise<undefined>;
+	get: <T>(key: string) => Promise<T | null>;
+	mget: <T>(keys: string[]) => Promise<[T]>;
+	set: <T>(key: string, value: T, ttl?: number) => Promise<T>;
+	mset: <T>(
+		list: Array<{
+			key: string;
+			value: T;
+			ttl?: number;
+		}>
+	) => Promise<
+	Array<{
+		key: string;
+		value: T;
+		ttl?: number;
+	}>
+	>;
+	del: (key: string) => Promise<boolean>;
+	mdel: (keys: string[]) => Promise<boolean>;
+	clear: () => Promise<boolean>;
+	wrap: <T>(
+		key: string,
+		fnc: () => T | Promise<T>,
+		ttl?: number | ((value: T) => number),
+		refreshThreshold?: number
+	) => Promise<T>;
+	on: <E extends keyof Events>(
+		event: E,
+		listener: Events[E]
+	) => EventEmitter;
+	off: <E extends keyof Events>(
+		event: E,
+		listener: Events[E]
+	) => EventEmitter;
+	disconnect: () => Promise<undefined>;
 };
 
 export type Events = {

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -63,6 +63,7 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 	const stores = options?.stores?.length ? options.stores : [new Keyv()];
 	const nonBlocking = options?.nonBlocking ?? false;
 
+	// eslint-disable-next-line @typescript-eslint/ban-types
 	const get = async <T>(key: string): Promise<T | null> => {
 		let result = null;
 

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -14,7 +14,7 @@ export type CreateCacheOptions = {
 };
 
 export type Cache = {
-	get: <T>(key: string) => Promise<T | null>;
+	get: <T>(key: string) => Promise<T | undefined>;
 	mget: <T>(keys: string[]) => Promise<[T]>;
 	set: <T>(key: string, value: T, ttl?: number) => Promise<T>;
 	mset: <T>(

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -14,7 +14,7 @@ export type CreateCacheOptions = {
 };
 
 export type Cache = {
-	get: <T>(key: string) => Promise<T | undefined>;
+	get: <T>(key: string) => Promise<T | null>;
 	mget: <T>(keys: string[]) => Promise<[T]>;
 	set: <T>(key: string, value: T, ttl?: number) => Promise<T>;
 	mset: <T>(
@@ -62,7 +62,7 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 	const stores = options?.stores?.length ? options.stores : [new Keyv()];
 	const nonBlocking = options?.nonBlocking ?? false;
 
-	const get = async <T>(key: string) => {
+	const get = async <T>(key: string): Promise<T | null> => {
 		let result = null;
 
 		if (nonBlocking) {

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -13,6 +13,43 @@ export type CreateCacheOptions = {
 	nonBlocking?: boolean;
 };
 
+export type Cache = {
+  get: <T>(key: string) => Promise<T | null>;
+  mget: <T>(keys: string[]) => Promise<[T]>;
+  set: <T>(key: string, value: T, ttl?: number) => Promise<T>;
+  mset: <T>(
+    list: Array<{
+      key: string;
+      value: T;
+      ttl?: number;
+    }>
+  ) => Promise<
+    {
+      key: string;
+      value: T;
+      ttl?: number;
+    }[]
+  >;
+  del: (key: string) => Promise<boolean>;
+  mdel: (keys: string[]) => Promise<boolean>;
+  clear: () => Promise<boolean>;
+  wrap: <T>(
+    key: string,
+    fnc: () => T | Promise<T>,
+    ttl?: number | ((value: T) => number),
+    refreshThreshold?: number
+  ) => Promise<T>;
+  on: <E extends keyof Events>(
+    event: E,
+    listener: Events[E]
+  ) => EventEmitter<[never]>;
+  off: <E extends keyof Events>(
+    event: E,
+    listener: Events[E]
+  ) => EventEmitter<[never]>;
+  disconnect: () => Promise<undefined>;
+};
+
 export type Events = {
 	set: <T>(data: {key: string; value: T; error?: unknown}) => void;
 	del: (data: {key: string; error?: unknown}) => void;
@@ -20,7 +57,7 @@ export type Events = {
 	refresh: <T>(data: {key: string; value: T; error?: unknown}) => void;
 };
 
-export const createCache = (options?: CreateCacheOptions) => {
+export const createCache = (options?: CreateCacheOptions): Cache => {
 	const eventEmitter = new EventEmitter();
 	const stores = options?.stores?.length ? options.stores : [new Keyv()];
 	const nonBlocking = options?.nonBlocking ?? false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Solves #923 

This PR introduces a named return type, `Cache`, for the `createCache()` method. This type explicitly defines the structure of the cache instance, enabling:
Improved type inference and autocomplete in TypeScript.
Easier integration with frameworks like NestJS by allowing direct reference to the `Cache` type.
Stronger type guarantees, ensuring compatibility with future updates.

**Does this PR introduce a breaking change?**
No. The changes are fully backward compatible. The new type definition is an explicit representation of the existing inferred type, so no runtime behavior is affected.

**Code example**
```typescript
import { Cache, createCache } from 'cache-manager';

const cache: Cache = createCache();

cache.set('key', 'value', 60).then(() => {
  cache.get<string>('key').then((value) => {
    console.log(value); // Outputs: 'value'
  });
});
```
