### PR TITLE
bugfix wrap function: nested wrap call on other cache instance - results in deadlock

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -181,6 +181,10 @@ const cache = createCache({ stores: [keyv] });
     * `clear` - will not wait for all stores to finish.
     * `wrap` - will do the same as `get` and `set` (return the first value found and not wait for all stores to finish).
 
+- **cacheId**?: string - Defaults to random string
+
+    Unique identifier for the cache instance.
+
 # Methods
 ## set
 `set(key, value, [ttl]): Promise<value>`
@@ -352,15 +356,26 @@ See unit tests in [`test/wrap.test.ts`](./test/wrap.test.ts) for more informatio
 
 ## disconnect
 
-`disconnect(key): Promise<void>`
+`disconnect(): Promise<void>`
 
-Will disconnect from the relevant store(s). It is highly recomended to use this when using a [Keyv](https://keyv.org/) storage adapter that requires a disconnect. For each storage adapter, the use case for when to use disconnect is different. An example is that `@keyv/redis` should be used only when you are done with the cache.
+Will disconnect from the relevant store(s). It is highly recommended to use this when using a [Keyv](https://keyv.org/) storage adapter that requires a disconnect. For each storage adapter, the use case for when to use disconnect is different. An example is that `@keyv/redis` should be used only when you are done with the cache.
 
 ```ts
 await cache.disconnect();
 ```
 
 See unit tests in [`test/disconnect.test.ts`](./test/disconnect.test.ts) for more information.
+
+## cacheId
+`cacheId(): string`
+
+Returns cache instance id.
+
+```ts
+const cache = createCache({cacheId: 'my-cache-id'});
+cache.cacheId(); // => 'my-cache-id'
+```
+See unit tests in [`test/cache-id.test.ts`](./test/get.test.ts) for more information.
 
 # Events
 ## set

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -64,6 +64,7 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 	const eventEmitter = new EventEmitter();
 	const stores = options?.stores?.length ? options.stores : [new Keyv()];
 	const nonBlocking = options?.nonBlocking ?? false;
+	const cacheId = Math.random().toString(36).slice(2);
 
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	const get = async <T>(key: string): Promise<T | null> => {
@@ -250,7 +251,7 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 		fnc: () => T | Promise<T>,
 		ttl?: number | ((value: T) => number),
 		refreshThreshold?: number,
-	): Promise<T> => coalesceAsync(key, async () => {
+	): Promise<T> => coalesceAsync(`${cacheId}__${key}`, async () => {
 		let value: T | undefined;
 		let i = 0;
 		let remainingTtl: number | undefined;
@@ -281,7 +282,7 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 		const shouldRefresh = lt(remainingTtl, refreshThreshold ?? options?.refreshThreshold);
 
 		if (shouldRefresh) {
-			coalesceAsync(`+++${key}`, fnc)
+			coalesceAsync(`+++${cacheId}__${key}`, fnc)
 				.then(async result => {
 					try {
 						await set(options?.refreshAllStores ? stores : stores.slice(0, i + 1), key, result, resolveTtl(result));

--- a/packages/cache-manager/test/cache-id.test.ts
+++ b/packages/cache-manager/test/cache-id.test.ts
@@ -1,0 +1,22 @@
+import {Keyv} from 'keyv';
+import {
+	beforeEach, describe, expect, it,
+} from 'vitest';
+import {createCache} from '../src/index.js';
+
+describe('cacheId', () => {
+	let keyv: Keyv;
+
+	beforeEach(async () => {
+		keyv = new Keyv();
+	});
+
+	it('user set', () => {
+		const cache = createCache({stores: [keyv], cacheId: 'my-cache-id'});
+		expect(cache.cacheId()).toEqual('my-cache-id');
+	});
+	it('auto generated', () => {
+		const cache = createCache({stores: [keyv]});
+		expect(cache.cacheId()).toBeTypeOf('string');
+	});
+});

--- a/packages/cache-manager/test/wrap.test.ts
+++ b/packages/cache-manager/test/wrap.test.ts
@@ -97,6 +97,15 @@ describe('wrap', () => {
 		expect(getTtlFunction).toHaveBeenNthCalledWith(2, 12); // Ttl func called 2nd time triggered by refreshThreshold on fresh item
 	});
 
+	it('should support nested calls of other caches - no mutual state', async () => {
+		const getValueA = vi.fn(() => 'A');
+		const getValueB = vi.fn(() => 'B');
+		const anotherCache = createCache({stores: [new Keyv()]});
+		expect(await cache.wrap(data.key, async () => anotherCache.wrap(data.key, getValueB).then((v) => v + getValueA()))).toEqual('BA');
+		expect(getValueA).toHaveBeenCalledOnce();
+		expect(getValueB).toHaveBeenCalledOnce();
+	});
+
 	it('store get failed', async () => {
 		const getValue = vi.fn(() => data.value);
 		keyv.get = () => {


### PR DESCRIPTION
`wrap` function: nested `wrap` call on other cache instance with same key - results in deadlock, where `wrap` function call hangs indefinitely
