### PR TITLE
cache-manager:wrap() method - support options parameter and raw return data

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -330,7 +330,7 @@ Wraps a function in cache. The first time the function is run, its results are s
 
 If `refreshThreshold` is set and the remaining TTL is less than `refreshThreshold`, the system will update the value asynchronously. In the meantime, the system will return the old value until expiration. You can also provide a function that will return the refreshThreshold based on the value `(value:T) => number`.
 
-If the options syntax for the optional parameters is used, an additional `raw` parameter can be applied, changing the function return type to   raw data including expiration timestamp as `{ value: [data], expires: [timestamp] }`.
+If the object format for the optional parameters is used, an additional `raw` parameter can be applied, changing the function return type to raw data including expiration timestamp as `{ value: [data], expires: [timestamp] }`.
 
 ```typescript
 await cache.wrap('key', () => 1, 5000, 3000)

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -322,9 +322,15 @@ See unit tests in [`test/clear.test.ts`](./test/clear.test.ts) for more informat
 ## wrap
 `wrap(key, fn: async () => value, [ttl], [refreshThreshold]): Promise<value>`
 
+Alternatively, with optional parameters as options object supporting a `raw` parameter:
+
+`wrap(key, fn: async () => value, { ttl?: number, refreshThreshold?: number, raw?: true }): Promise<value>`
+
 Wraps a function in cache. The first time the function is run, its results are stored in cache so subsequent calls retrieve from cache instead of calling the function.
 
 If `refreshThreshold` is set and the remaining TTL is less than `refreshThreshold`, the system will update the value asynchronously. In the meantime, the system will return the old value until expiration. You can also provide a function that will return the refreshThreshold based on the value `(value:T) => number`.
+
+If the options syntax for the optional parameters is used, an additional `raw` parameter can be applied, changing the function return type to   raw data including expiration timestamp as `{ value: [data], expires: [timestamp] }`.
 
 ```typescript
 await cache.wrap('key', () => 1, 5000, 3000)
@@ -334,6 +340,10 @@ await cache.wrap('key', () => 1, 5000, 3000)
 await cache.wrap('key', () => 2, 5000, 3000)
 // return data from cache, function will not be called again
 // => 1
+
+await cache.wrap('key', () => 2, { ttl: 5000, refreshThreshold: 3000, raw: true })
+// returns raw data including expiration timestamp
+// => { value: 1, expires: [timestamp] }
 
 // wait 3 seconds
 await sleep(3000)

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -273,13 +273,13 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 		key: string,
 		fnc: () => T | Promise<T>,
 		ttlOrOptions?: number | ((value: T) => number) | Partial<WrapOptionsRaw<T>>,
-		refreshThresholdParam?: number | ((value: T) => number),
+		refreshThresholdParameter?: number | ((value: T) => number),
 	): Promise<T | StoredDataRaw<T>> => coalesceAsync(`${_cacheId}::${key}`, async () => {
 		let value: T | undefined;
 		let data: StoredDataRaw<T> | undefined;
 		let i = 0;
 		let remainingTtl: number | undefined;
-		const {ttl, refreshThreshold, raw} = isObject(ttlOrOptions) ? ttlOrOptions : {ttl: ttlOrOptions, refreshThreshold: refreshThresholdParam};
+		const {ttl, refreshThreshold, raw} = isObject(ttlOrOptions) ? ttlOrOptions : {ttl: ttlOrOptions, refreshThreshold: refreshThresholdParameter};
 		const resolveTtl = (result: T) => runIfFn(ttl, result) ?? options?.ttl;
 
 		for (; i < stores.length; i++) {

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -301,9 +301,9 @@ export const createCache = (options?: CreateCacheOptions): Cache => {
 
 		if (value === undefined) {
 			const result = await fnc();
-			const ttl = resolveTtl(result);
+			const ttl = resolveTtl(result)!;
 			await set(stores, key, result, ttl);
-			return raw ? {value: result, expires: Date.now() + (ttl ?? 0)} : result;
+			return raw ? {value: result, expires: Date.now() + ttl} : result;
 		}
 
 		const shouldRefresh = lt(remainingTtl, runIfFn(refreshThreshold, value) ?? options?.refreshThreshold);

--- a/packages/cache-manager/src/is-object.ts
+++ b/packages/cache-manager/src/is-object.ts
@@ -1,0 +1,3 @@
+export function isObject<T = Record<string, unknown>>(value: unknown): value is T {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/cache-manager/test/wrap.test.ts
+++ b/packages/cache-manager/test/wrap.test.ts
@@ -43,6 +43,18 @@ describe('wrap', () => {
 		expect(getTtlFunction).toHaveBeenCalledTimes(1);
 	});
 
+	it('ttl - options', async () => {
+		await cache.wrap(data.key, async () => data.value, {ttl});
+		await expect(cache.get(data.key)).resolves.toEqual(data.value);
+		await sleep(ttl + 100);
+		await expect(cache.get(data.key)).resolves.toBeNull();
+	});
+
+	it('returns raw data', async () => {
+		await expect(cache.wrap(data.key, () => data.value, {ttl, raw: true}))
+			.resolves.toEqual({value: data.value, expires: expect.any(Number)});
+	});
+
 	it('calls fn once to fetch value on cache miss when invoked multiple times', async () => {
 		const getValue = vi.fn().mockResolvedValue(data.value);
 
@@ -65,16 +77,17 @@ describe('wrap', () => {
 		}
 	});
 
-	it('should allow dynamic refreshThreshold on wrap function', async () => {
-		const config = {ttl: 2000, refreshThreshold: 1000};
-
+	it.each([
+		[2000, 1000],
+		[{ttl: 2000, refreshThreshold: 1000}, undefined],
+	])('should allow dynamic refreshThreshold on wrap function with ttl/options param as %s', async (ttlOrOptions, refreshThreshold) => {
 		// 1st call should be cached
-		expect(await cache.wrap(data.key, async () => 0, config.ttl, config.refreshThreshold)).toEqual(0);
+		expect(await cache.wrap(data.key, async () => 0, ttlOrOptions as never, refreshThreshold)).toEqual(0);
 		await sleep(1001);
 		// Background refresh, but stale value returned
-		expect(await cache.wrap(data.key, async () => 1, config.ttl, config.refreshThreshold)).toEqual(0);
+		expect(await cache.wrap(data.key, async () => 1, ttlOrOptions as never, refreshThreshold)).toEqual(0);
 		// New value in cache
-		expect(await cache.wrap(data.key, async () => 2, config.ttl, config.refreshThreshold)).toEqual(1);
+		expect(await cache.wrap(data.key, async () => 2, ttlOrOptions as never, refreshThreshold)).toEqual(1);
 
 		await sleep(1001);
 		// No background refresh with the new override params

--- a/packages/cache-manager/test/wrap.test.ts
+++ b/packages/cache-manager/test/wrap.test.ts
@@ -50,9 +50,20 @@ describe('wrap', () => {
 		await expect(cache.get(data.key)).resolves.toBeNull();
 	});
 
-	it('returns raw data', async () => {
+	it('returns single value or raw storage-data', async () => {
+		// Run pristine and expect single value
+		await expect(cache.wrap(data.key, () => data.value, ttl))
+			.resolves.toEqual(data.value);
+		// Expect cached response with raw data
 		await expect(cache.wrap(data.key, () => data.value, {ttl, raw: true}))
 			.resolves.toEqual({value: data.value, expires: expect.any(Number)});
+
+		// Run pristine with new key and expect raw data
+		await expect(cache.wrap(data.key + 'i', () => data.value, {ttl, raw: true}))
+			.resolves.toEqual({value: data.value, expires: expect.any(Number)});
+		// Expect cached response with single value
+		await expect(cache.wrap(data.key + 'i', () => data.value, ttl))
+			.resolves.toEqual(data.value);
 	});
 
 	it('calls fn once to fetch value on cache miss when invoked multiple times', async () => {


### PR DESCRIPTION
cache-manager: wrap() method:
-  add support for an options object parameter instead of the separate `ttl` and `refreshThreshold` params.
- additionally a new parameter is added to the options object, that will change the method's return value to raw stored data including expiration timestamp.

Closes https://github.com/jaredwray/cacheable/issues/997
