### PR TITLE
cacheable - fix: deleting a key should delete entry from hash cache

### DIFF
--- a/packages/cacheable/src/memory.ts
+++ b/packages/cacheable/src/memory.ts
@@ -365,6 +365,7 @@ export class CacheableMemory extends Hookified {
 	public delete(key: string): void {
 		const store = this.getStore(key);
 		store.delete(key);
+		this._hashCache.delete(key);
 	}
 
 	/**
@@ -462,8 +463,8 @@ export class CacheableMemory extends Hookified {
 	 * @returns {number} from 0 to 9
 	 */
 	public hashKey(key: string): number {
-		const cacheHashNumber = this._hashCache.get(key)!;
-		if (cacheHashNumber) {
+		const cacheHashNumber = this._hashCache.get(key);
+		if (typeof cacheHashNumber === 'number') {
 			return cacheHashNumber;
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfils these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a bug fix and a small improvement.

### Bug Fix
The bug fix is related to the _hashCache variable not having its key deleted when it's deleted from the store. This would result in increasing memory consumption over time.
A use case: you receive a lot of IDs (1000s / second) and you want to cache them for a short period of time (using TTL). They are deleted from the store, but not from the hashCache, thus increasing the memory consumption indefinitely.

I could also add this change under an opt-in flag if the current behaviour is intended (e.g. if a key is deleted, but later you check it again and you don't want to compute the hash again). This would be fine for a reduced number of unique keys (< 10k? )

### Improvement
The hashKey function would compute the hash over and over for values stored in storage index 0.
