### PR TITLE
cache-manager - fix: in-memory defaults on createCache with no serial…

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -38,14 +38,26 @@ const memoryCache = createCache(memoryStore({
 }));
 ```
 
-In `v6` you can use any storage adapter that Keyv supports. Below is an example of how to migrate from `v5` to `v6` using `CacheableMemory` from Cacheable:
+In `v6` you can use any storage adapter that Keyv supports. Below is an example of using the in memory store with `Keyv`:
 
 ```ts
 import { createCache } from 'cache-manager';
-import { Keyv } from 'keyv';
+
+const cache = createCache();
+```
+
+If you would like to do multiple stores you can do the following:
+
+```ts
+import { createCache } from 'cache-manager';
+import { createKeyv } from 'cacheable';
+import { createKeyv as createKeyvRedis } from '@keyv/redis';
+
+const memoryStore = createKeyv();
+const redisStore = createKeyvRedis('redis://user:pass@localhost:6379');
 
 const cache = createCache({
-  stores: [new Keyv()],
+  stores: [memoryStore, redisStore],
 });
 ```
 
@@ -69,10 +81,10 @@ If you would like a more robust in memory storage adapter you can use `Cacheable
 
 ```ts
 import { createCache } from 'cache-manager';
-import { KeyvCacheableMemory } from 'cacheable';
+import { createKeyv } from 'cacheable';
 
 const cache = createCache({
-  stores: [new KeyvCacheableMemory({ ttl: 60000, lruSize: 5000 })],
+  stores: [createKeyv({ ttl: 60000, lruSize: 5000 })],
 });
 ```
 

--- a/packages/cache-manager/src/index.ts
+++ b/packages/cache-manager/src/index.ts
@@ -86,7 +86,10 @@ export type Events = {
 
 export const createCache = (options?: CreateCacheOptions): Cache => {
 	const eventEmitter = new EventEmitter();
-	const stores = options?.stores?.length ? options.stores : [new Keyv()];
+	const keyv = new Keyv();
+	keyv.serialize = undefined;
+	keyv.deserialize = undefined;
+	const stores = options?.stores?.length ? options.stores : [keyv];
 	const nonBlocking = options?.nonBlocking ?? false;
 	const _cacheId = options?.cacheId ?? Math.random().toString(36).slice(2);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
With the migration to `Keyv` as the core storage adapter in `cache-manager v6` it has caused multiple issues with the simple in memory because Keyv by default does *serialization*. Here is an example:

```js
import { createCache } from 'cache-manager';
const cache = createCache();
```

This creates a simple in memory cache and with `v5` it had no serialization. To resolve this we need to set `keyv.serialize` and `keyv.deserialize` to `undefined`. 

This fix makes it so the default Keyv if you specify no store will handle this by default. 

#843, #1079 