### PR TITLE
file-entry-cache - chore: upgrading vitest to 3.1.3

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -36,12 +36,12 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"devDependencies": {
-		"@types/node": "^22.14.0",
-		"@vitest/coverage-v8": "^3.1.1",
+		"@types/node": "^22.15.8",
+		"@vitest/coverage-v8": "^3.1.3",
 		"rimraf": "^6.0.1",
 		"tsup": "^8.4.0",
-		"typescript": "^5.8.2",
-		"vitest": "^3.1.1",
+		"typescript": "^5.8.3",
+		"vitest": "^3.1.3",
 		"xo": "^0.60.0"
 	},
 	"dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - chore: upgrading vitest to 3.1.3