### PR TITLE
cacheable - feat: Expose raw option on get / getMany to surface TTL/expiration

### DIFF
--- a/packages/cacheable/README.md
+++ b/packages/cacheable/README.md
@@ -214,6 +214,40 @@ cache.ttl = -1; // sets the default ttl to 0 which is disabled
 console.log(cache.ttl); // undefined
 ```
 
+## Retrieving raw cache entries
+
+The `get` and `getMany` methods support a `raw` option, which returns the full stored metadata (`StoredDataRaw<T>`) instead of just the value:
+
+```typescript
+import { Cacheable } from 'cacheable';
+
+const cache = new Cacheable();
+
+// store a value
+await cache.set('user:1', { name: 'Alice' });
+
+// default: only the value
+const user = await cache.get<{ name: string }>('user:1');
+console.log(user); // { name: 'Alice' }
+
+// with raw: full record including expiration
+const raw = await cache.get<{ name: string }>('user:1', { raw: true });
+console.log(raw.value);   // { name: 'Alice' }
+console.log(raw.expires); // e.g. 1677628495000 or null
+```
+
+```typescript
+// getMany with raw option
+await cache.set('a', 1);
+await cache.set('b', 2);
+
+const raws = await cache.getMany<number>(['a', 'b'], { raw: true });
+raws.forEach((entry, idx) => {
+  console.log(`key=${['a','b'][idx]}, value=${entry?.value}, expires=${entry?.expires}`);
+});
+```
+
+
 # Non-Blocking Operations
 
 If you want your layer 2 (secondary) store to be non-blocking you can set the `nonBlocking` property to `true` in the options. This will make the secondary store non-blocking and will not wait for the secondary store to respond on `setting data`, `deleting data`, or `clearing data`. This is useful if you want to have a faster response time and not wait for the secondary store to respond.
@@ -272,7 +306,9 @@ _This does not enable statistics for your layer 2 cache as that is a distributed
 * `set(key, value, ttl?)`: Sets a value in the cache.
 * `setMany([{key, value, ttl?}])`: Sets multiple values in the cache.
 * `get(key)`: Gets a value from the cache.
+* `get(key, { raw: true })`: Gets a raw value from the cache.
 * `getMany([keys])`: Gets multiple values from the cache.
+* `getMany([keys], { raw: true })`: Gets multiple raw values from the cache.
 * `has(key)`: Checks if a value exists in the cache.
 * `hasMany([keys])`: Checks if multiple values exist in the cache.
 * `take(key)`: Takes a value from the cache and deletes it.

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -226,6 +226,13 @@ describe('cacheable get method', async () => {
 		const result = await cacheable.get('key');
 		expect(result).toEqual('value');
 	});
+	test('should get a raw data object', async () => {
+		const cacheable = new Cacheable();
+		await cacheable.set('rawKey', 'rawValue');
+		const raw = await cacheable.get('rawKey', {raw: true});
+		expect(raw).toHaveProperty('value', 'rawValue');
+		expect(raw).toHaveProperty('expires');
+	});
 	test('should throw on get', async () => {
 		const keyv = new Keyv();
 		vi.spyOn(keyv, 'get').mockImplementation(async () => {
@@ -272,6 +279,17 @@ describe('cacheable get method', async () => {
 		await cacheable.set('key2', 'value2');
 		const result = await cacheable.getMany(['key1', 'key2']);
 		expect(result).toEqual(['value1', 'value2']);
+	});
+	test('should get raw data objects with getMany', async () => {
+		const cacheable = new Cacheable();
+		await cacheable.set('rawKey1', 'value1');
+		await cacheable.set('rawKey2', 'value2');
+		const raws = await cacheable.getMany(['rawKey1', 'rawKey2'], {raw: true});
+		expect(raws).toHaveLength(2);
+		expect(raws[0]).toHaveProperty('value', 'value1');
+		expect(raws[0]).toHaveProperty('expires');
+		expect(raws[1]).toHaveProperty('value', 'value2');
+		expect(raws[1]).toHaveProperty('expires');
 	});
 	test('should throw on getMany', async () => {
 		const keyv = new Keyv();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

Proposal from the #1116 issue

**What kind of change does this PR introduce?** 

This pull request introduces a new "raw" mode for the `get` and `getMany` methods in the `Cacheable` library, allowing users to retrieve full metadata for cache entries instead of just the stored values. The changes include updates to the library's implementation, documentation, and tests.

### New Feature: Raw Mode for Cache Retrieval
* Added support for a `raw` option in the `get` and `getMany` methods, enabling retrieval of full metadata (`StoredDataRaw<T>`) for cache entries. This includes updates to method signatures, logic for handling primary and secondary stores, and the return structure. (`packages/cacheable/src/index.ts`, [[1]](diffhunk://#diff-e787642663183987ec0514d540e867e94325aeee022004cfe2c05a93b1e72ebaL293-R323) [[2]](diffhunk://#diff-e787642663183987ec0514d540e867e94325aeee022004cfe2c05a93b1e72ebaL331-R370) [[3]](diffhunk://#diff-e787642663183987ec0514d540e867e94325aeee022004cfe2c05a93b1e72ebaL354-L364) [[4]](diffhunk://#diff-e787642663183987ec0514d540e867e94325aeee022004cfe2c05a93b1e72ebaL387-R412)

### Documentation Updates
* Updated the `README.md` file to document the new `raw` option for `get` and `getMany` methods, including usage examples and explanations. (`packages/cacheable/README.md`, [[1]](diffhunk://#diff-08ad1ab0a3aa711f9fbe7a01cc817c3741f1b55c25915b1d9d255b9f803d2933R217-R250) [[2]](diffhunk://#diff-08ad1ab0a3aa711f9fbe7a01cc817c3741f1b55c25915b1d9d255b9f803d2933R309-R311)

### Test Enhancements
* Added unit tests to verify the functionality of the `raw` option in both `get` and `getMany` methods, ensuring correct handling of raw data objects and their properties. (`packages/cacheable/test/index.test.ts`, [[1]](diffhunk://#diff-99cc1964e2a824c750ec119757de12451ffbffcf7e8ab318b30289816b850468R229-R235) [[2]](diffhunk://#diff-99cc1964e2a824c750ec119757de12451ffbffcf7e8ab318b30289816b850468R283-R293)