### PR TITLE
file-entry-cache - chore: upgrading vitest to 3.2.2

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -37,11 +37,11 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.15.8",
-		"@vitest/coverage-v8": "^3.1.3",
+		"@vitest/coverage-v8": "^3.2.2",
 		"rimraf": "^6.0.1",
 		"tsup": "^8.4.0",
 		"typescript": "^5.8.3",
-		"vitest": "^3.1.3",
+		"vitest": "^3.2.2",
 		"xo": "^1.1.0"
 	},
 	"dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - chore: upgrading vitest to 3.2.2