### PR TITLE
file-entry-cache - chore: upgrading vitest to 3.2.4

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -36,12 +36,12 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"devDependencies": {
-		"@types/node": "^22.15.30",
-		"@vitest/coverage-v8": "^3.2.2",
+		"@types/node": "^24.0.7",
+		"@vitest/coverage-v8": "^3.2.4",
 		"rimraf": "^6.0.1",
 		"tsup": "^8.5.0",
 		"typescript": "^5.8.3",
-		"vitest": "^3.2.2",
+		"vitest": "^3.2.4",
 		"xo": "^1.1.1"
 	},
 	"dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - chore: upgrading vitest to 3.2.4