### PR TITLE
fix: pass createKey option through wrap methods

### DIFF
--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -754,6 +754,7 @@ export class Cacheable extends Hookified {
 		const wrapOptions = {
 			ttl: options?.ttl ?? this._ttl,
 			keyPrefix: options?.keyPrefix,
+			createKey: options?.createKey,
 			cache: this,
 			cacheId: this._cacheId,
 		};

--- a/packages/cacheable/src/memory.ts
+++ b/packages/cacheable/src/memory.ts
@@ -684,6 +684,7 @@ export class CacheableMemory extends Hookified {
 		const wrapOptions = {
 			ttl: options?.ttl ?? this._ttl,
 			keyPrefix: options?.keyPrefix,
+			createKey: options?.createKey,
 			cache: this,
 		};
 

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -708,6 +708,22 @@ describe("cacheable wrap", async () => {
 		const result3 = await wrapped(1);
 		expect(result3).not.toBe(result2);
 	});
+
+	test("Cacheable.wrap() passes createKey option through", async () => {
+		const cacheable = new Cacheable();
+		let createKeyCalled = false;
+		const asyncFunction = async (argument: string) => `Result for ${argument}`;
+		const options = {
+			createKey: () => {
+				createKeyCalled = true;
+				return "testKey";
+			},
+		};
+
+		const wrapped = cacheable.wrap(asyncFunction, options);
+		await wrapped("arg1");
+		expect(createKeyCalled).toBe(true);
+	});
 });
 
 describe("cacheable namespace", async () => {

--- a/packages/cacheable/test/wrap.test.ts
+++ b/packages/cacheable/test/wrap.test.ts
@@ -378,4 +378,20 @@ describe("wrap functions handling thrown errors", () => {
 
 		expect(result1).toBe(result2);
 	});
+
+	it("CacheableMemory.wrap() passes createKey option through", () => {
+		const cache = new CacheableMemory();
+		let createKeyCalled = false;
+		const testFunction = (argument: string) => `Result for ${argument}`;
+		const options = {
+			createKey: () => {
+				createKeyCalled = true;
+				return "testKey";
+			},
+		};
+
+		const wrapped = cache.wrap(testFunction, options);
+		wrapped("arg1");
+		expect(createKeyCalled).toBe(true);
+	});
 });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -678,6 +678,7 @@ export class CacheableMemory extends Hookified {
 		const wrapOptions = {
 			ttl: options?.ttl ?? this._ttl,
 			keyPrefix: options?.keyPrefix,
+			createKey: options?.createKey,
 			cache: this as CacheSyncInstance,
 		};
 

--- a/packages/memory/test/index.test.ts
+++ b/packages/memory/test/index.test.ts
@@ -702,6 +702,22 @@ describe("cacheable wrap", async () => {
 		expect(result).toBe(result2); // Cached
 	});
 
+	test("CacheableMemory.wrap() passes createKey option through", () => {
+		const cacheable = new CacheableMemory();
+		let createKeyCalled = false;
+		const testFunction = (argument: string) => `Result for ${argument}`;
+		const options = {
+			createKey: () => {
+				createKeyCalled = true;
+				return "testKey";
+			},
+		};
+
+		const wrapped = cacheable.wrap(testFunction, options);
+		wrapped("arg1");
+		expect(createKeyCalled).toBe(true);
+	});
+
 	test("should be able to pass in expiration time", async () => {
 		const cacheable = new CacheableMemory();
 		const expire = Date.now() + 100;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - pass createKey option through wrap methods

The `createKey` option was not being passed from `wrap()` methods to the underlying `wrapSync`/`wrap` functions, preventing custom cache key generation from working.

Fixed in:
- `@cacheable/cacheable`: `CacheableMemory.wrap()` and `Cacheable.wrap()`
- `@cacheable/memory`: `CacheableMemory.wrap()`