### PR TITLE
cache-manager - feat: add store layer identification to event payloads

### DIFF
--- a/packages/cache-manager/test/events.test.ts
+++ b/packages/cache-manager/test/events.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test file
 import { faker } from "@faker-js/faker";
 import { Keyv } from "keyv";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/cache-manager/test/multiple-stores.test.ts
+++ b/packages/cache-manager/test/multiple-stores.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: test file
 import { faker } from "@faker-js/faker";
 import { Keyv } from "keyv";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/cache-manager/test/multiple-stores.test.ts
+++ b/packages/cache-manager/test/multiple-stores.test.ts
@@ -111,4 +111,52 @@ describe("multiple stores", () => {
 			"new",
 		);
 	});
+
+	it("event: get emits store id for secondary hit", async () => {
+		const events: any[] = [];
+
+		cache.on("get", (e: any) => events.push(e));
+
+		await keyv2.set(data.key, data.value);
+		await expect(cache.get(data.key)).resolves.toEqual(data.value);
+
+		const rec = events.find((e) => e.key === data.key);
+
+		expect(rec).toBeTruthy();
+		expect(typeof rec.store).toBe("string");
+		expect(rec.store).not.toBe("primary");
+	});
+
+	it("event: set emits store id per layer (primary + secondary)", async () => {
+		const events: any[] = [];
+
+		cache.on("set", (e: any) => events.push(e));
+
+		await cache.set(data.key, data.value, ttl);
+
+		const stores = events.filter((e) => e.key === data.key).map((e) => e.store);
+
+		expect(stores.length).toBeGreaterThanOrEqual(2);
+		expect(new Set(stores).size).toBeGreaterThanOrEqual(2);
+		expect(stores).toContain("primary");
+		expect(stores).toContain("secondary:0");
+	});
+
+	it("event: get includes store for deeper layers (secondary:1)", async () => {
+		const l1 = new Keyv();
+		const l2 = new Keyv();
+		const l3 = new Keyv();
+
+		const cache = createCache({ stores: [l1, l2, l3] });
+
+		const events: any[] = [];
+		cache.on("get", (e: any) => events.push(e));
+
+		await l3.set(data.key, data.value);
+		await expect(cache.get(data.key)).resolves.toEqual(data.value);
+
+		const rec = events.find((e) => e.key === data.key);
+
+		expect(rec.store).toBe("secondary:1");
+	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [X] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Implements [#1128](https://github.com/jaredwray/cacheable/issues/1128) by adding **store layer identification** to event payloads in `cache-manager`.  

Previously, event payloads (`get`, `set`, etc.) did not include which store/layer (primary or secondary) was responsible. This limited monitoring and debugging when multiple stores were configured.

### Changes
- Added `_storeLabel` helper:
  - `"primary"` for index `0`
  - `"secondary:N"` for deeper layers
- Updated `get` and `set` (including errors) to emit the `store` field in event payloads.
- Added unit tests:
  - **events.test.ts** – verifies `get` payload includes store and value, error events include store.
  - **multiple-stores.test.ts** – verifies secondary hit emits correct store, per-layer `set` emits store IDs, and deeper layers (e.g., `"secondary:1"`) are labeled correctly.

### Motivation
This enables:
- Monitoring hit/miss rates per cache layer  
- Debugging which layer served a value  
- Collecting metrics for performance and cost optimization  

### Result
Event payloads are now enriched with `store` information while maintaining backward compatibility.