### PR TITLE
Fix class name in documentation

### DIFF
--- a/packages/node-cache/README.md
+++ b/packages/node-cache/README.md
@@ -290,13 +290,13 @@ await cache.get('foo'); // 'bar'
 Here is an example of how to use the `NodeCacheStore` with a primary and secondary storage adapter:
 
 ```javascript
-import {NodeStorageCache} from '@cacheable/node-cache';
+import {NodeCacheStore} from '@cacheable/node-cache';
 import {Keyv} from 'keyv';
 import {KeyvRedis} from '@keyv/redis';
 
 const primary = new Keyv(); // In-memory storage as primary
 const secondary = new Keyv({store: new KeyvRedis('redis://user:pass@localhost:6379')});
-const cache = new NodeStorageCache({primary, secondary});
+const cache = new NodeCacheStore({primary, secondary});
 
 // with storage you have the same functionality as the NodeCache but will be using async/await
 await cache.set('foo', 'bar');


### PR DESCRIPTION
These are the only two references to `NodeStorageCache`. Clippy asks "Did you mean `NodeCacheStore`?"

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. (N/A: docs update)
- [x] Docs have been added / updated (for bug fixes / features)

This is a pure docs update to correct the class name in the sample code.
