### PR TITLE
file-entry-cache - fix: removing useModifiedTime as not needed

### DIFF
--- a/packages/file-entry-cache/test/index.test.ts
+++ b/packages/file-entry-cache/test/index.test.ts
@@ -41,13 +41,6 @@ describe("file-entry-cache with options", () => {
 		expect(fileEntryCache.useCheckSum).toBe(false);
 	});
 
-	test("should be able to get and set useModifiedTime", () => {
-		const fileEntryCache = new FileEntryCache({ useModifiedTime: true });
-		expect(fileEntryCache.useModifiedTime).toBe(true);
-		fileEntryCache.useModifiedTime = false;
-		expect(fileEntryCache.useModifiedTime).toBe(false);
-	});
-
 	test("create should initialize a file-entry-cache", () => {
 		const fileEntryCache = defaultFileEntryCache.create("test1");
 		expect(fileEntryCache).toBeDefined();
@@ -236,17 +229,6 @@ describe("getFileDescriptor()", () => {
 		expect(fileDescriptor.meta).toBeDefined();
 		expect(fileDescriptor.meta?.size).toBe(4);
 		expect(fileDescriptor.meta?.hash).to.not.toBeDefined();
-	});
-
-	test("should return a file descriptor without useModifiedTime", () => {
-		const fileEntryCache = new FileEntryCache();
-		const testFile1 = path.resolve("./.cacheGFD/test2.txt");
-		const fileDescriptor = fileEntryCache.getFileDescriptor(testFile1, {
-			useModifiedTime: false,
-		});
-		expect(fileDescriptor).toBeDefined();
-		expect(fileDescriptor.key).toBe(testFile1);
-		expect(fileDescriptor.meta?.hash).toBeUndefined();
 	});
 
 	test("should return a file descriptor with checksum", () => {

--- a/packages/file-entry-cache/test/relative-eslint.test.ts
+++ b/packages/file-entry-cache/test/relative-eslint.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import fileEntryCache from "../src/index.js";
+
+describe("eslint tests scenarios", () => {
+	test("relative pathing works on files and cache", () => {
+		// create the unique cache so there are no conflicts
+		const cacheDirectory = ".cache";
+		const file = "./index.ts";
+		const useCheckSum = true;
+		const testFixturesPath = "./test/fixtures-relative";
+		const testFixturesPathRename = "./test/fixtures-relative-foo";
+		const cache = fileEntryCache.create(
+			".eslintcache-foo43",
+			cacheDirectory,
+			useCheckSum,
+			path.resolve("./src"),
+		);
+
+		const indexDescriptor1 = cache.getFileDescriptor(file);
+
+		expect(indexDescriptor1.changed).toBe(true);
+
+		cache.reconcile();
+
+		// validate that it didnt change
+		const indexDescriptor2 = cache.getFileDescriptor(file);
+
+		expect(indexDescriptor2.changed).toBe(false);
+		expect(indexDescriptor1.meta.hash).toEqual(indexDescriptor2.meta.hash);
+
+		// copy the file into a temp directory to show a move
+		fs.cpSync("./src/index.ts", `${testFixturesPath}/index.ts`, {
+			force: true,
+		});
+
+		// update the cwd path
+		cache.cwd = path.resolve(testFixturesPath);
+
+		const indexDescriptor3 = cache.getFileDescriptor(file);
+
+		// validate that the file via hash is not different
+		expect(indexDescriptor3.changed).toBe(false);
+
+		// rename the fixtures path
+		fs.renameSync(testFixturesPath, testFixturesPathRename);
+
+		// change the cwd again
+		cache.cwd = path.resolve(testFixturesPathRename);
+
+		// get the file again in the new current working directory
+		const indexDescriptor4 = cache.getFileDescriptor(file);
+
+		// validate a final time that if renamed folder but file is same it is good
+		expect(indexDescriptor4.changed).toBe(false);
+		expect(indexDescriptor4.meta.hash).toEqual(indexDescriptor1.meta.hash);
+
+		// clean up
+		fs.rmSync(path.resolve(cacheDirectory), {
+			recursive: true,
+			force: true,
+		});
+
+		fs.rmSync(path.resolve(testFixturesPath), {
+			recursive: true,
+			force: true,
+		});
+
+		fs.rmSync(path.resolve(testFixturesPathRename), {
+			recursive: true,
+			force: true,
+		});
+	});
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - fix: removing useModifiedTime as not needed