### PR TITLE
file-entry-cache - feat: adding in test example for eslint

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.5",
-		"@types/node": "^24.7.0",
+		"@types/node": "^24.7.1",
 		"@vitest/coverage-v8": "^3.2.4",
 		"pino": "^10.0.0",
 		"rimraf": "^6.0.1",

--- a/packages/file-entry-cache/test/relative-eslint.test.ts
+++ b/packages/file-entry-cache/test/relative-eslint.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
 import fileEntryCache, {
+	type CreateOptions,
 	FileEntryCache,
 	type FileEntryCacheOptions,
 } from "../src/index.js";
@@ -96,6 +97,35 @@ describe("eslint tests scenarios", () => {
 		};
 
 		const cache = new FileEntryCache(options);
+
+		const fileDescriptor = cache.getFileDescriptor(file);
+
+		expect(fileDescriptor.changed).toBe(true);
+		expect(fileDescriptor.meta.hash).toBeDefined();
+
+		cache.reconcile();
+
+		const fileDescriptor2 = cache.getFileDescriptor(file);
+
+		expect(fileDescriptor2.changed).toBe(false);
+		expect(fileDescriptor2.meta.hash).toBeDefined();
+	});
+
+	test("create with cwd and use absolute path key", () => {
+		const cacheDirectory = "./.cache";
+		const cacheId = ".eslintcache-202121212";
+		const file = "../src/index.ts";
+		const useCheckSum = true;
+		const useAbsolutePathAsKey = true;
+		const cwd = cacheDirectory;
+
+		const options: CreateOptions = {
+			useCheckSum,
+			useAbsolutePathAsKey,
+			cwd,
+		};
+
+		const cache = fileEntryCache.create(cacheId, cacheDirectory, options);
 
 		const fileDescriptor = cache.getFileDescriptor(file);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - feat: adding in test example for eslint