### PR TITLE
file-entry-cache - chore: upgrading @types/node to 24.7.2

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.5",
-		"@types/node": "^24.7.1",
+		"@types/node": "^24.7.2",
 		"@vitest/coverage-v8": "^3.2.4",
 		"pino": "^10.0.0",
 		"rimraf": "^6.0.1",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cacheable/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
file-entry-cache - chore: upgrading @types/node to 24.7.2