### PR TITLE
flat-cache - chore: bump `flatted` version from `v3.3.3` -> `v3.4.1`

### DIFF
--- a/packages/flat-cache/package.json
+++ b/packages/flat-cache/package.json
@@ -74,7 +74,7 @@
 	},
 	"dependencies": {
 		"cacheable": "workspace:^",
-		"flatted": "^3.3.3",
+		"flatted": "^3.4.1",
 		"hookified": "^1.15.0"
 	},
 	"files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
         specifier: workspace:^
         version: link:../cacheable
       flatted:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.1
+        version: 3.4.1
       hookified:
         specifier: ^1.15.0
         version: 1.15.0
@@ -2462,8 +2462,8 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -6136,7 +6136,7 @@ snapshots:
       mlly: 1.8.0
       rollup: 4.57.1
 
-  flatted@3.3.3: {}
+  flatted@3.4.1: {}
 
   flattie@1.1.1: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bump `flatted` version from `v3.3.3` -> `v3.4.1` to apply the fix for the following CVE:
- https://github.com/advisories/GHSA-25h7-pfq9-p65f 