### PR TITLE
node-cache - fix: prototype pollution vulnerability in mget methods

### DIFF
--- a/packages/node-cache/src/index.ts
+++ b/packages/node-cache/src/index.ts
@@ -267,7 +267,10 @@ export class NodeCache<T> extends Hookified {
 	public mget<V = T>(
 		keys: Array<string | number>,
 	): Record<string, V | undefined> {
-		const result: Record<string, V | undefined> = {};
+		const result: Record<string, V | undefined> = Object.create(null) as Record<
+			string,
+			V | undefined
+		>;
 
 		for (const key of keys) {
 			const value = this.get(key);

--- a/packages/node-cache/src/store.ts
+++ b/packages/node-cache/src/store.ts
@@ -118,7 +118,10 @@ export class NodeCacheStore<T> extends Hookified {
 	public async mget<V = T>(
 		keys: Array<string | number>,
 	): Promise<Record<string, V | undefined>> {
-		const result: Record<string, V | undefined> = {};
+		const result: Record<string, V | undefined> = Object.create(null) as Record<
+			string,
+			V | undefined
+		>;
 		for (const key of keys) {
 			const value = await this._keyv.get<V>(key.toString());
 			if (value === undefined) {

--- a/packages/node-cache/test/index.test.ts
+++ b/packages/node-cache/test/index.test.ts
@@ -93,6 +93,14 @@ describe("NodeCache", () => {
 		expect(list[key2]).toBe(value2);
 	});
 
+	test("should not pollute Object.prototype via mget with __proto__ key", () => {
+		cache.set("__proto__", { polluted: true });
+		const result = cache.mget(["__proto__"]);
+		// biome-ignore lint/suspicious/noExplicitAny: testing prototype pollution
+		expect((Object.prototype as any).polluted).toBeUndefined();
+		expect(result.__proto__).toEqual({ polluted: true });
+	});
+
 	test("should take a key", () => {
 		const key = faker.string.uuid();
 		const val = faker.lorem.word();

--- a/packages/node-cache/test/index.test.ts
+++ b/packages/node-cache/test/index.test.ts
@@ -98,7 +98,8 @@ describe("NodeCache", () => {
 		const result = cache.mget(["__proto__"]);
 		// biome-ignore lint/suspicious/noExplicitAny: testing prototype pollution
 		expect((Object.prototype as any).polluted).toBeUndefined();
-		expect(result.__proto__).toEqual({ polluted: true });
+		expect(Object.getPrototypeOf(result)).toBeNull();
+		expect(Object.hasOwn(result, "__proto__")).toBe(true);
 	});
 
 	test("should take a key", () => {

--- a/packages/node-cache/test/store.test.ts
+++ b/packages/node-cache/test/store.test.ts
@@ -78,7 +78,8 @@ describe("NodeCacheStore", () => {
 		const result = await store.mget(["__proto__"]);
 		// biome-ignore lint/suspicious/noExplicitAny: testing prototype pollution
 		expect((Object.prototype as any).polluted).toBeUndefined();
-		expect(result.__proto__).toEqual({ polluted: true });
+		expect(Object.getPrototypeOf(result)).toBeNull();
+		expect(Object.hasOwn(result, "__proto__")).toBe(true);
 	});
 	test("should be able to set multiple keys", async () => {
 		const store = new NodeCacheStore();

--- a/packages/node-cache/test/store.test.ts
+++ b/packages/node-cache/test/store.test.ts
@@ -72,6 +72,14 @@ describe("NodeCacheStore", () => {
 		const result1 = await store.mget(["test1", "test2"]);
 		expect(result1).toEqual({ test1: "value1", test2: "value2" });
 	});
+	test("should not pollute Object.prototype via mget with __proto__ key", async () => {
+		const store = new NodeCacheStore();
+		await store.set("__proto__", { polluted: true });
+		const result = await store.mget(["__proto__"]);
+		// biome-ignore lint/suspicious/noExplicitAny: testing prototype pollution
+		expect((Object.prototype as any).polluted).toBeUndefined();
+		expect(result.__proto__).toEqual({ polluted: true });
+	});
 	test("should be able to set multiple keys", async () => {
 		const store = new NodeCacheStore();
 		const data = [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

Bug fix - Security

**Description**

This PR fixes a prototype pollution vulnerability in the `mget` methods of both `NodeCache` and `NodeCacheStore` classes. The vulnerability occurred because the result object was created using object literal syntax (`{}`), which inherits from `Object.prototype`. When a key named `__proto__` was stored and retrieved, it could pollute the prototype chain.

**Changes**

- Modified `NodeCache.mget()` to create the result object using `Object.create(null)` instead of `{}`
- Modified `NodeCacheStore.mget()` to create the result object using `Object.create(null)` instead of `{}`
- Added comprehensive tests in both test suites to verify that storing and retrieving `__proto__` keys does not pollute `Object.prototype`

The `Object.create(null)` approach creates an object with no prototype chain, preventing any possibility of prototype pollution while maintaining the same functional behavior for legitimate use cases.

**Test Plan**

Added unit tests that verify:
1. The `__proto__` key can be stored and retrieved normally
2. `Object.prototype` remains unpolluted after operations with `__proto__` keys
3. The returned object correctly contains the `__proto__` property without affecting the global prototype

All existing tests continue to pass with this change.

https://claude.ai/code/session_01MhMFGu517ERhcLM4M5DsM8