### PR TITLE
cacheable - fix: upgrade lru-cache to 11.3.6

### DIFF
--- a/packages/cacheable/package.json
+++ b/packages/cacheable/package.json
@@ -38,7 +38,7 @@
 		"@keyv/redis": "^5.1.6",
 		"@keyv/valkey": "^1.0.11",
 		"@qified/redis": "^0.9.0",
-		"lru-cache": "^11.2.7",
+		"lru-cache": "^11.3.6",
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0(qified@0.9.0)
       lru-cache:
-        specifier: ^11.2.7
-        version: 11.2.7
+        specifier: ^11.3.6
+        version: 11.3.6
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.5.0)
@@ -3041,6 +3041,10 @@ packages:
 
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
@@ -6868,6 +6872,8 @@ snapshots:
 
   lru-cache@11.2.7: {}
 
+  lru-cache@11.3.6: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -7624,7 +7630,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.3.6
       minipass: 7.1.3
 
   path-to-regexp@3.3.0: {}


### PR DESCRIPTION
## Summary
- Upgrade `lru-cache` (devDependency) from 11.2.7 to 11.3.6 in the `cacheable` package.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm test` passes for `cacheable` (8 test files, 206 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)