### PR TITLE
file-entry-cache - fix: upgrade pino to 10.3.1

### DIFF
--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -43,7 +43,7 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"devDependencies": {
-		"pino": "^10.1.1",
+		"pino": "^10.3.1",
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         version: link:../flat-cache
     devDependencies:
       pino:
-        specifier: ^10.1.1
-        version: 10.1.1
+        specifier: ^10.3.1
+        version: 10.3.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.5.0)
@@ -3515,8 +3515,8 @@ packages:
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
-  pino@10.1.1:
-    resolution: {integrity: sha512-3qqVfpJtRQUCAOs4rTOEwLH6mwJJ/CSAlbis8fKOiMzTtXh0HN/VLsn3UWVTJ7U8DsWmxeNon2IpGb+wORXH4g==}
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
   pirates@4.0.7:
@@ -7649,7 +7649,7 @@ snapshots:
 
   pino-std-serializers@7.1.0: {}
 
-  pino@10.1.1:
+  pino@10.3.1:
     dependencies:
       '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0


### PR DESCRIPTION
## Summary
- Upgrade `pino` (devDependency) from 10.1.1 to 10.3.1 in the `file-entry-cache` package.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm --filter file-entry-cache test` passes (6 test files, 92 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)