### PR TITLE
@cacheable/benchmark - fix: upgrade @faker-js/faker to 10.4.0 (breaking)

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"@cacheable/memory": "workspace:^",
-		"@faker-js/faker": "^9.8.0",
+		"@faker-js/faker": "^10.4.0",
 		"@monstermann/tinybench-pretty-printer": "^0.1.0",
 		"bentocache": "^1.4.0",
 		"cache-manager": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:^
         version: link:../memory
       '@faker-js/faker':
-        specifier: ^9.8.0
-        version: 9.8.0
+        specifier: ^10.4.0
+        version: 10.4.0
       '@monstermann/tinybench-pretty-printer':
         specifier: ^0.1.0
         version: 0.1.0(tinybench@4.0.1)
@@ -1122,10 +1122,6 @@ packages:
   '@faker-js/faker@10.4.0':
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
-
-  '@faker-js/faker@9.8.0':
-    resolution: {integrity: sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==}
-    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -4907,8 +4903,6 @@ snapshots:
     optional: true
 
   '@faker-js/faker@10.4.0': {}
-
-  '@faker-js/faker@9.8.0': {}
 
   '@gar/promisify@1.1.3':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrade `@faker-js/faker` from 9.8.0 to 10.4.0 in `@cacheable/benchmark` to align with the workspace root.

## Notes
- Faker 10 dropped CommonJS support and requires Node 20+; the benchmark package is private and only uses the modern ESM API, so call sites are unaffected.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm --filter @cacheable/benchmark test` passes (lint only — package has no tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)