### PR TITLE
@cacheable/memory - docs: clarify that lruSize=0 disables LRU (fixes #1637)

### DIFF
--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -8,7 +8,7 @@
 [![npm](https://img.shields.io/npm/v/@cacheable/memory.svg)](https://www.npmjs.com/package/@cacheable/memory)
 [![license](https://img.shields.io/github/license/jaredwray/cacheable)](https://github.com/jaredwray/cacheable/blob/main/LICENSE)
 
-You can use `CacheableMemory` as a standalone cache or as a primary store for `cacheable`. You can also set the `useClones` property to `false` if you want to use the same reference for the values. This is useful if you are using large objects and want to save memory. The `lruSize` property is the size of the LRU cache and is set to `0` by default, which disables the LRU cache (no LRU eviction is performed and the cache size is bounded only by the underlying `Map` stores). When setting the `lruSize` property to a value greater than `0` it will limit the number of keys in the cache and evict the least recently used entries when full.
+You can use `CacheableMemory` as a standalone cache or as a primary store for `cacheable`. You can also set the `useClones` property to `false` if you want to use the same reference for the values. This is useful if you are using large objects and want to save memory. The `lruSize` property is the size of the LRU cache and is set to `0` by default, which disables the LRU cache (no LRU eviction is performed and the cache size is bounded only by the underlying `Map` stores). When the `lruSize` property is set to a value greater than `0`, it limits the number of keys in the cache and evicts the least recently used entries when full.
 
 This simple in-memory cache uses multiple Map objects and a with `expiration` and `lru` policies if set to manage the in memory cache at scale.
 
@@ -188,7 +188,7 @@ const value = cache.get('key'); // value
 
 You can enable the LRU (Least Recently Used) feature in `CacheableMemory` by setting the `lruSize` property in the options. This will limit the number of keys in the cache to the size you set. When the cache reaches the limit it will remove the least recently used keys from the cache. This is useful if you want to limit the memory usage of the cache.
 
-When you set the `lruSize` we use a double linked list to track the LRU order across the underlying `Map` stores. The `lruSize` itself is capped at `16,777,216 (2^24) keys` — values above this limit are rejected and an `error` event is emitted. Setting `lruSize` does not change `storeHashSize`; the underlying stores keep whatever `storeHashSize` you configured (default `16`).
+When you set the `lruSize`, we use a doubly linked list to track the LRU order across the underlying `Map` stores. The `lruSize` itself is capped at `16,777,216 (2^24) keys` — values above this limit are rejected and an `error` event is emitted. Setting `lruSize` does not change `storeHashSize`; the underlying stores keep whatever `storeHashSize` you configured (default `16`).
 
 ```javascript
 import { CacheableMemory } from 'cacheable';

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -8,7 +8,7 @@
 [![npm](https://img.shields.io/npm/v/@cacheable/memory.svg)](https://www.npmjs.com/package/@cacheable/memory)
 [![license](https://img.shields.io/github/license/jaredwray/cacheable)](https://github.com/jaredwray/cacheable/blob/main/LICENSE)
 
-You can use `CacheableMemory` as a standalone cache or as a primary store for `cacheable`. You can also set the `useClones` property to `false` if you want to use the same reference for the values. This is useful if you are using large objects and want to save memory. The `lruSize` property is the size of the LRU cache and is set to `0` by default which is unlimited. When setting the `lruSize` property it will limit the number of keys in the cache.
+You can use `CacheableMemory` as a standalone cache or as a primary store for `cacheable`. You can also set the `useClones` property to `false` if you want to use the same reference for the values. This is useful if you are using large objects and want to save memory. The `lruSize` property is the size of the LRU cache and is set to `0` by default, which disables the LRU cache (no LRU eviction is performed and the cache size is bounded only by the underlying `Map` stores). When setting the `lruSize` property to a value greater than `0` it will limit the number of keys in the cache and evict the least recently used entries when full.
 
 This simple in-memory cache uses multiple Map objects and a with `expiration` and `lru` policies if set to manage the in memory cache at scale.
 
@@ -188,11 +188,11 @@ const value = cache.get('key'); // value
 
 You can enable the LRU (Least Recently Used) feature in `CacheableMemory` by setting the `lruSize` property in the options. This will limit the number of keys in the cache to the size you set. When the cache reaches the limit it will remove the least recently used keys from the cache. This is useful if you want to limit the memory usage of the cache.
 
-When you set the `lruSize` we use a double linked list to manage the LRU cache and also set the `hashStoreSize` to `1` which means we will only use a single `Map` object for the LRU cache. This is because the LRU cache is managed by the double linked list and it is not possible to have more than `16,777,216 (2^24) keys` in a single `Map` object.
+When you set the `lruSize` we use a double linked list to track the LRU order across the underlying `Map` stores. The `lruSize` itself is capped at `16,777,216 (2^24) keys` — values above this limit are rejected and an `error` event is emitted. Setting `lruSize` does not change `storeHashSize`; the underlying stores keep whatever `storeHashSize` you configured (default `16`).
 
 ```javascript
 import { CacheableMemory } from 'cacheable';
-const cache = new CacheableMemory({ lruSize: 1 }); // sets the LRU cache size to 1000 keys and hashStoreSize to 1
+const cache = new CacheableMemory({ lruSize: 1 }); // sets the LRU cache size to 1 key
 cache.set('key1', 'value1');
 cache.set('key2', 'value2');
 const value1 = cache.get('key1');
@@ -230,7 +230,7 @@ As you can see from the benchmarks `CacheableMemory` is on par with other cachin
 
 * `ttl`: The time to live for the cache in milliseconds. Default is `undefined` which is means indefinitely.
 * `useClones`: If the cache should use clones for the values. Default is `true`.
-* `lruSize`: The size of the LRU cache. Default is `0` which is unlimited.
+* `lruSize`: The size of the LRU cache. Default is `0`, which disables the LRU cache (no LRU eviction is performed). Maximum is `16,777,216 (2^24)`.
 * `checkInterval`: The interval to check for expired keys in milliseconds. Default is `0` which is disabled.
 * `storeHashSize`: The number of `Map` objects to use for the cache. Default is `16`.
 * `storeHashAlgorithm`: The hashing algorithm to use for the cache. Default is `djb2`. Supported: DJB2, FNV1, MURMER, CRC32.
@@ -253,7 +253,7 @@ As you can see from the benchmarks `CacheableMemory` is on par with other cachin
 * `clear()`: Clears the cache.
 * `ttl`: The default time to live for the cache in milliseconds. Default is `undefined` which is disabled.
 * `useClones`: If the cache should use clones for the values. Default is `true`.
-* `lruSize`: The size of the LRU cache. Default is `0` which is unlimited.
+* `lruSize`: The size of the LRU cache. Default is `0`, which disables the LRU cache (no LRU eviction is performed). Maximum is `16,777,216 (2^24)`.
 * `size`: The number of keys in the cache.
 * `checkInterval`: The interval to check for expired keys in milliseconds. Default is `0` which is disabled.
 * `storeHashSize`: The number of `Map` objects to use for the cache. Default is `16`.


### PR DESCRIPTION
## Summary

Fixes #1637.

The `@cacheable/memory` README described `lruSize: 0` as "unlimited" in three places, but the JSDoc on `CacheableMemoryOptions.lruSize` and the actual code say it **disables** the LRU cache. The code is authoritative: `_lruSize` defaults to `0`, and `lruAddToFront` / `lruMoveToFront` / `lruRemove` all early-return when `_lruSize === 0`, and `set()` only performs eviction when `_lruSize > 0`. So with `lruSize: 0` the LRU is off entirely — the cache is bounded only by the underlying `Map` stores, which is *not* what "unlimited LRU" would imply to a reader.

While fixing that I also corrected two adjacent doc bugs in the same section:

- The "CacheableMemory LRU Feature" section claimed that setting `lruSize` also sets `hashStoreSize` to `1`. The constructor (`packages/memory/src/index.ts:79-94`) never touches `_storeHashSize` when `lruSize` is provided, so this is incorrect. Rewrote the paragraph to describe what actually happens (double-linked list + the `2^24` cap that emits an `error` event when exceeded).
- The LRU example's inline comment said `lruSize: 1` "sets the LRU cache size to 1000 keys and hashStoreSize to 1" — neither was true. Corrected to "sets the LRU cache size to 1 key".

No code changes; documentation only.

## Test plan

- [x] `pnpm test` passes (doc-only change; no code paths touched)
- [x] README renders correctly on GitHub
- [x] Wording aligns with `CacheableMemoryOptions.lruSize` JSDoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVzKRP1ah3YBqi4orRGhgZ)_