### PR TITLE
release: 2026-05-27 (8 packages)

### DIFF
--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-manager",
-  "version": "7.2.8",
+  "version": "7.2.9",
   "description": "Cache Manager for Node.js",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/cacheable/package.json
+++ b/packages/cacheable/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cacheable",
-	"version": "2.3.5",
+	"version": "2.4.0",
 	"description": "High Performance Layer 1 / Layer 2 Caching with Keyv Storage",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-entry-cache",
-	"version": "11.1.3",
+	"version": "11.1.4",
 	"description": "A lightweight cache for file metadata, ideal for processes that work on a specific set of files and only need to reprocess files that have changed since the last run",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/flat-cache/package.json
+++ b/packages/flat-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "flat-cache",
-	"version": "6.1.22",
+	"version": "6.1.23",
 	"description": "A simple key/value storage using files to persist the data",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cacheable/memory",
-	"version": "2.0.9",
+	"version": "2.1.0",
 	"description": "High Performance In-Memory Cache for Node.js",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cacheable/net",
-	"version": "2.0.8",
+	"version": "2.0.9",
 	"description": "High Performance Network Caching for Node.js with fetch, request, http 1.1, and http 2 support",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cacheable/node-cache",
-	"version": "3.0.1",
+	"version": "3.1.0",
 	"description": "Simple and Maintained fast NodeJS internal caching",
 	"type": "module",
 	"main": "./dist/index.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cacheable/utils",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Cacheable Utilities for Caching Libraries",
 	"type": "module",
 	"main": "./dist/index.cjs",


### PR DESCRIPTION
## Release summary

Releasing 8 packages: @cacheable/memory@2.1.0 (minor), @cacheable/node-cache@3.1.0 (minor), cacheable@2.4.0 (minor), cache-manager@7.2.9 (patch), file-entry-cache@11.1.4 (patch), flat-cache@6.1.23 (patch), @cacheable/net@2.0.9 (patch), @cacheable/utils@2.4.2 (patch).

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `@cacheable/memory` | `2.0.9` | `2.1.0` | **minor** | 2 feat (hooks, maxTtl), 1 build | 3 |
| `@cacheable/node-cache` | `3.0.1` | `3.1.0` | **minor** | 1 feat (enhanced store + bug fixes), 1 test | 3 |
| `cacheable` | `2.3.5` | `2.4.0` | **minor** | 1 feat (maxTtl), 1 build | 2 |
| `cache-manager` | `7.2.8` | `7.2.9` | patch | build: tsup→tsdown, pnpm 11 | 1 |
| `file-entry-cache` | `11.1.3` | `11.1.4` | patch | build: tsup→tsdown, pnpm 11 | 1 |
| `flat-cache` | `6.1.22` | `6.1.23` | patch | build: tsup→tsdown, pnpm 11 | 1 |
| `@cacheable/net` | `2.0.8` | `2.0.9` | patch | build: tsup→tsdown, pnpm 11 | 1 |
| `@cacheable/utils` | `2.4.1` | `2.4.2` | patch | build: tsup→tsdown, pnpm 11 | 1 |
| `cacheable-request` | `13.0.19` | — | _skipped_ | no changes since v13.0.19 | 0 |
| `@cacheable/benchmark` | `1.0.0` | — | _skipped_ | not published on npm | 0 |
| `@cacheable/website` | `1.0.0` | — | _private_ | not published | 0 |

## @cacheable/memory@2.1.0 — 2026-05-27

Add lifecycle hooks and maxTtl cap to CacheableMemory.

### Features
- add hooks for all cache operations via `CacheableMemoryHooks` enum (1ff149d, #1644)

  ```ts
  import { CacheableMemory, CacheableMemoryHooks } from '@cacheable/memory';
  const cache = new CacheableMemory();
  cache.onHookSync(CacheableMemoryHooks.BEFORE_SET, (data) => {
    data.value = transform(data.value); // mutate before write
  });
  cache.set('key', 'value');
  ```

- add `maxTtl` option to cap maximum time-to-live (948234a, #1645)

  ```ts
  const cache = new CacheableMemory({ ttl: '10m', maxTtl: '1h' });
  cache.set('key', 'value', '2h'); // capped to 1h
  cache.set('key2', 'value2');     // no TTL → capped to 1h
  ```

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (3)

### Full List of Changes
- feat(cacheable, memory): add maxTtl option to cap maximum time-to-live by @jaredwray in #1645
- feat(@cacheable/memory): add hooks like cacheable by @jaredwray in #1644
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## @cacheable/node-cache@3.1.0 — 2026-05-27

Add keys/has/getTtl/flushAll, events, useClones, checkperiod, and fix multiple stat-tracking bugs.

### Features
- add `keys()` and `has()` methods for cache inspection (bf3ea48, #1643)

  ```ts
  const store = new NodeCacheStore();
  await store.set('a', 1);
  await store.keys();    // ['a']
  await store.has('a');  // true
  ```

- add `getTtl()` to inspect key expiration timestamps (bf3ea48, #1643)

  ```ts
  await store.set('key', 'val', 5000);
  const ttl = await store.getTtl('key'); // ms timestamp when key expires
  ```

- add `flushAll()` to clear data and reset all stats (bf3ea48, #1643)

  ```ts
  await store.flushAll(); // clears data + resets stats, emits "flush"
  ```

- add event emitters for `set`, `del`, `expired`, and `flush` operations (bf3ea48, #1643)

  ```ts
  store.on('set', (key, value, ttl) => { /* ... */ });
  store.on('del', (key, value) => { /* ... */ });
  store.on('expired', (key, value) => { /* ... */ });
  store.on('flush', () => { /* ... */ });
  ```

- add `useClones` option for deep-cloning via structuredClone (bf3ea48, #1643)

  ```ts
  const store = new NodeCacheStore({ useClones: true });
  ```

- add `checkperiod` option for interval-based expired item detection (bf3ea48, #1643)

  ```ts
  const store = new NodeCacheStore({ checkperiod: 60 }); // check every 60s
  store.close(); // stop interval
  ```

- add `deleteOnExpire` option and `close()`/`getIntervalId()` lifecycle methods (bf3ea48, #1643)

### Bug Fixes
- fix `setTtl()` treating falsy cached values (0, "", false, null) as non-existent (bf3ea48, #1643)
- fix `mdel()` firing stats and events for non-existent keys (bf3ea48, #1643)
- fix `startInterval()` leaking old timer when called twice (bf3ea48, #1643)
- fix `set()` double-counting stats on key overwrites (bf3ea48, #1643)
- fix `checkData()` swallowing unhandled promise rejections (bf3ea48, #1643)
- fix `handleExpired()` stats underflow when Keyv auto-expires items (bf3ea48, #1643)
- fix `checkData()` mutating Map during iteration (bf3ea48, #1643)

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)
- move store tests to use @faker-js/faker (d51b5f2, #1641)

### Contributors
- @jaredwray (3)

### Full List of Changes
- feat(@cacheable/node-cache): enhance NodeCacheStore with missing features by @jaredwray in #1643
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642
- @cacheable/node-cache: move store tests to use @faker-js/faker by @jaredwray in #1641

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## cacheable@2.4.0 — 2026-05-27

Add maxTtl option to enforce an upper bound on cache entry lifetimes.

### Features
- add `maxTtl` option to cap maximum time-to-live on `set()` and `setMany()` (948234a, #1645)

  ```ts
  import { Cacheable } from 'cacheable';
  const cache = new Cacheable({ ttl: '10m', maxTtl: '1h' });
  await cache.set('key', 'value', '2h'); // capped to 1h
  await cache.set('key2', 'value2');     // no TTL → capped to 1h
  ```

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (2)

### Full List of Changes
- feat(cacheable, memory): add maxTtl option to cap maximum time-to-live by @jaredwray in #1645
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## cache-manager@7.2.9 — 2026-05-27

Build tooling migration to tsdown and pnpm 11.

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (1)

### Full List of Changes
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## file-entry-cache@11.1.4 — 2026-05-27

Build tooling migration to tsdown and pnpm 11.

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (1)

### Full List of Changes
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## flat-cache@6.1.23 — 2026-05-27

Build tooling migration to tsdown and pnpm 11.

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (1)

### Full List of Changes
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## @cacheable/net@2.0.9 — 2026-05-27

Build tooling migration to tsdown and pnpm 11.

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (1)

### Full List of Changes
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## @cacheable/utils@2.4.2 — 2026-05-27

Build tooling migration to tsdown and pnpm 11.

### Internal
- migrate build from tsup to tsdown, pnpm 11 (1508695, #1642)

### Contributors
- @jaredwray (1)

### Full List of Changes
- feat: Migrate to pnpm 11 with corepack and tsdown from tsup by @jaredwray in #1642

**Full diff:** https://github.com/jaredwray/cacheable/compare/9346f94...claude/vibrant-turing-Lt1n0

---

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] Tests pass locally for all packages with available services (memory, node-cache, flat-cache, utils at 100% coverage)
- [x] Pre-existing test failures on `main` confirmed for packages requiring Redis/network services (cacheable, cache-manager, net, file-entry-cache, cacheable-request)
- [x] No uncommitted changes outside the version bump

## Post-merge
- Merge — **no publish workflow detected**; publish manually with `npm publish` per package or set up a workflow per `release-management-nodejs.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHRKp9uLbfAsRAFPcDgZQx)_