### PR TITLE
feat(net): add WHOIS and RDAP lookups to @cacheable/net

### DIFF
--- a/packages/net/README.md
+++ b/packages/net/README.md
@@ -20,10 +20,12 @@ Features:
 * Full TypeScript support with comprehensive type definitions
 * Request-level cache control with the `caching` option
 * All the features of [cacheable](https://npmjs.com/package/cacheable) - layered caching, LRU, TTL expiration, and more!
+* `whois` and `rdap` lookups for domains, IPs, and ASNs with **both raw and JSON output**, dynamic IANA server discovery, referral following, and built-in caching
 * Extensively tested with 100% code coverage
 
 # Table of Contents
 * [Getting Started](#getting-started)
+* [WHOIS and RDAP Lookups](#whois-and-rdap-lookups)
 * [How to Contribute](#how-to-contribute)
 * [License and Copyright](#license-and-copyright)
 
@@ -201,6 +203,97 @@ By default:
 - To enable caching for POST/PUT/PATCH/DELETE, set `caching: true` in the options
 - To disable caching for GET/HEAD, set `caching: false` in the options
 
+
+# WHOIS and RDAP Lookups
+
+`@cacheable/net` ships first-class lookups for domains, IP addresses (v4/v6), and ASNs over both
+the traditional **WHOIS** protocol (TCP port 43) and the modern **RDAP** protocol (HTTPS/JSON).
+WHOIS returns the registry's **raw text** which is also parsed into a JSON object, while RDAP
+returns native JSON. The authoritative server is discovered dynamically through IANA and cached, so
+you never have to ship or maintain a static list of TLD servers.
+
+Because WHOIS and RDAP servers are heavily rate-limited, results are cached (and concurrent
+identical lookups are coalesced) using the same `cacheable` instance as the rest of the library.
+
+## WHOIS
+
+```javascript
+import { CacheableNet } from '@cacheable/net';
+
+const net = new CacheableNet();
+
+const result = await net.whois('example.com');
+
+result.raw;     // the full raw WHOIS text (all hops joined)
+result.fields;  // parsed JSON, e.g. { "Domain Name": "EXAMPLE.COM", "Name Server": ["A", "B"] }
+result.server;  // the authoritative server that produced the data
+result.type;    // "domain" | "ipv4" | "ipv6" | "asn"
+result.hops;    // every server response in order (registry, registrar, ...)
+```
+
+You can also use the standalone functions. `whoisRaw` returns just the raw text:
+
+```javascript
+import { whois, whoisRaw } from '@cacheable/net';
+
+const { fields } = await whois('8.8.8.8');   // IP address lookup
+const { fields: asn } = await whois('AS15169'); // ASN lookup
+const raw = await whoisRaw('example.com');   // raw text only
+```
+
+By default a registry response's `Registrar WHOIS Server` referral is followed to fetch fuller
+data. Control this with the `follow` option (`false`/`0` to disable, `true` for the default depth,
+or a number of hops):
+
+```javascript
+const shallow = await net.whois('example.com', { follow: false }); // registry only
+const deep = await net.whois('example.com', { follow: 2 });        // follow up to 2 referrals
+```
+
+### WhoisOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `server` | `string` | – | Query this server directly and skip IANA discovery |
+| `port` | `number` | `43` | TCP port for the initial server |
+| `timeout` | `number` | `10000` | Socket timeout in milliseconds |
+| `follow` | `boolean \| number` | `true` | Follow registry → registrar referrals (`true` = depth 2) |
+| `queryPrefix` | `string` | `""` | Text written before the query (e.g. `"domain "` for some registries) |
+| `encoding` | `BufferEncoding` | `"utf8"` | Encoding used to decode responses |
+| `caching` | `boolean` | `true` | Disable caching for this lookup when `false` |
+| `cache` | `Cacheable` | instance cache | Cache instance (standalone `whois` caches only when provided) |
+| `ttl` | `number \| string` | instance default | TTL override for the cached result |
+
+## RDAP
+
+RDAP is the modern, fully structured replacement for WHOIS. The RDAP server is resolved from the
+IANA bootstrap registries (cached through the library's own `fetch`).
+
+```javascript
+import { CacheableNet, rdap } from '@cacheable/net';
+
+const net = new CacheableNet();
+
+const result = await net.rdap('example.com');
+result.data;   // parsed RDAP object
+result.raw;    // raw JSON text
+result.server; // the RDAP base URL used
+
+// standalone, with IP and ASN support
+const ip = await rdap('1.1.1.1');
+const asn = await rdap('AS15169');
+```
+
+### RdapOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `server` | `string` | – | Query this RDAP base URL directly and skip bootstrap discovery |
+| `bootstrapUrl` | `string` | `https://data.iana.org/rdap` | Override the IANA bootstrap base URL |
+| `headers` | `Record<string, string>` | – | Additional request headers |
+| `caching` | `boolean` | `true` | Disable caching for this lookup when `false` |
+| `cache` | `Cacheable` | instance cache | Cache instance (standalone `rdap` caches only when provided) |
+| `ttl` | `number \| string` | instance default | TTL override for the cached result |
 
 # How to Contribute
 

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cacheable/net",
 	"version": "2.0.9",
-	"description": "High Performance Network Caching for Node.js with fetch, request, http 1.1, and http 2 support",
+	"description": "High Performance Network Caching for Node.js with fetch, http 1.1, http 2, and cached WHOIS and RDAP lookups",
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
@@ -21,7 +21,7 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/jaredwray/cacheable.git",
-		"directory": "packages/cacheable"
+		"directory": "packages/net"
 	},
 	"author": "Jared Wray <me@jaredwray.com>",
 	"license": "MIT",
@@ -55,6 +55,11 @@
 		"http 2 caching",
 		"dns caching",
 		"whois caching",
+		"whois",
+		"rdap",
+		"whois lookup",
+		"rdap lookup",
+		"domain lookup",
 		"high performance",
 		"layer 1 caching",
 		"layer 2 caching",

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -7,6 +7,8 @@ import {
 	fetch,
 	makeResponse,
 } from "./fetch.js";
+import { type RdapOptions, type RdapResult, rdap } from "./rdap.js";
+import { type WhoisOptions, type WhoisResult, whois } from "./whois.js";
 
 export type NetFetchOptions = {
 	/**
@@ -638,6 +640,56 @@ export class CacheableNet extends Hookified {
 	}
 
 	/**
+	 * Perform a WHOIS lookup for a domain, IP address, or ASN, returning both the
+	 * raw text and parsed JSON fields. Uses the instance cache so repeated lookups
+	 * are served from cache and concurrent identical lookups are coalesced. To
+	 * disable caching for a single lookup, set `options.caching` to false.
+	 * @param {string} query The domain, URL, IP address, or ASN to look up.
+	 * @param {WhoisOptions} options Optional lookup options.
+	 * @returns {Promise<WhoisResult>} The raw text and parsed fields.
+	 */
+	public async whois(
+		query: string,
+		options?: WhoisOptions,
+	): Promise<WhoisResult> {
+		const whoisOptions: WhoisOptions = {
+			...options,
+			cache: this._cache,
+		};
+
+		// remove cache if they explicitly disable caching
+		if (options?.caching === false) {
+			delete whoisOptions.cache;
+		}
+
+		return whois(query, whoisOptions);
+	}
+
+	/**
+	 * Perform an RDAP lookup for a domain, IP address, or ASN, returning both the
+	 * raw JSON text and the parsed object. Uses the instance cache so repeated
+	 * lookups are served from cache and concurrent identical lookups are
+	 * coalesced. To disable caching for a single lookup, set `options.caching` to
+	 * false.
+	 * @param {string} query The domain, URL, IP address, or ASN to look up.
+	 * @param {RdapOptions} options Optional lookup options.
+	 * @returns {Promise<RdapResult>} The raw JSON text and parsed data.
+	 */
+	public async rdap(query: string, options?: RdapOptions): Promise<RdapResult> {
+		const rdapOptions: RdapOptions = {
+			...options,
+			cache: this._cache,
+		};
+
+		// remove cache if they explicitly disable caching
+		if (options?.caching === false) {
+			delete rdapOptions.cache;
+		}
+
+		return rdap(query, rdapOptions);
+	}
+
+	/**
 	 * Sets the Content-Type header if not already set.
 	 * Checks both "Content-Type" and "content-type" to handle case variations.
 	 * @param headers - The headers object to modify
@@ -669,3 +721,22 @@ export {
 	post,
 	type Response as FetchResponse,
 } from "./fetch.js";
+export {
+	type RdapOptions,
+	type RdapResult,
+	rdap,
+} from "./rdap.js";
+export {
+	detectQueryType,
+	normalizeWhoisQuery,
+	parseWhois,
+	type QueryWhoisServerOptions,
+	queryWhoisServer,
+	type WhoisFields,
+	type WhoisHop,
+	type WhoisOptions,
+	type WhoisQueryType,
+	type WhoisResult,
+	whois,
+	whoisRaw,
+} from "./whois.js";

--- a/packages/net/src/rdap.ts
+++ b/packages/net/src/rdap.ts
@@ -135,7 +135,9 @@ function ipv6ToBigInt(ip: string): bigint {
 	const [head, tail] = ip.split("::");
 	const headParts = head ? head.split(":") : [];
 	const tailParts = tail ? tail.split(":") : [];
-	const missing = 8 - headParts.length - tailParts.length;
+	// Clamp so a malformed address with more than 8 groups never yields a
+	// negative length (which would make Array() throw a RangeError).
+	const missing = Math.max(0, 8 - headParts.length - tailParts.length);
 	const parts = [...headParts, ...Array(missing).fill("0"), ...tailParts];
 	return parts.reduce(
 		(accumulator, part) =>
@@ -235,6 +237,11 @@ async function resolveRdapBase(
 	const base = trimTrailingSlash(options.bootstrapUrl ?? IANA_RDAP_BOOTSTRAP);
 	const url = `${base}/${bootstrapFileForType(type)}`;
 	const response = await fetch(url, buildFetchOptions(options.headers, cache));
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch RDAP bootstrap from ${url}: ${response.status} ${response.statusText}`,
+		);
+	}
 	const bootstrap = JSON.parse(await response.text()) as RdapBootstrap;
 
 	const rdapBase = findRdapBase(bootstrap, type, normalized);

--- a/packages/net/src/rdap.ts
+++ b/packages/net/src/rdap.ts
@@ -1,0 +1,314 @@
+import { coalesceAsync } from "@cacheable/utils";
+import type { Cacheable } from "cacheable";
+import { type FetchOptions, fetch } from "./fetch.js";
+import {
+	detectQueryType,
+	normalizeWhoisQuery,
+	type WhoisQueryType,
+} from "./whois.js";
+
+/**
+ * The base URL of the IANA RDAP bootstrap registries.
+ * @see https://data.iana.org/rdap/
+ */
+const IANA_RDAP_BOOTSTRAP = "https://data.iana.org/rdap";
+
+/**
+ * The shape of an IANA RDAP bootstrap registry file. Each service maps a list of
+ * keys (TLDs, CIDR ranges, or ASN ranges) to a list of RDAP base URLs.
+ * @see https://www.rfc-editor.org/rfc/rfc9224
+ */
+type RdapBootstrap = {
+	services: Array<[string[], string[]]>;
+};
+
+/**
+ * The result of an RDAP lookup, exposing both the raw JSON text and the parsed
+ * object.
+ */
+export type RdapResult = {
+	/** The normalized query that was looked up. */
+	query: string;
+	/** The detected type of the query. */
+	type: WhoisQueryType;
+	/** The RDAP base URL that produced the data. */
+	server: string;
+	/** The raw JSON text returned by the server. */
+	raw: string;
+	/** The parsed RDAP object. */
+	data: Record<string, unknown>;
+};
+
+/**
+ * Options for {@link rdap}.
+ */
+export type RdapOptions = {
+	/**
+	 * Override the RDAP base URL to query. When set, the IANA bootstrap step is
+	 * skipped and this server is queried directly.
+	 */
+	server?: string;
+	/** Override the IANA bootstrap base URL. @default "https://data.iana.org/rdap" */
+	bootstrapUrl?: string;
+	/** Additional request headers to send with the RDAP request. */
+	headers?: Record<string, string>;
+	/**
+	 * Enable or disable caching for this lookup. When `false`, no caching is
+	 * performed even if a cache is available. @default true (when a cache is available)
+	 */
+	caching?: boolean;
+	/** The cache instance. The standalone {@link rdap} caches only when this is provided. */
+	cache?: Cacheable;
+	/** An optional TTL override for cached results (milliseconds or shorthand). */
+	ttl?: number | string;
+};
+
+/**
+ * Remove a trailing slash from a URL, if present.
+ */
+function trimTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/**
+ * Ensure a URL ends with a single trailing slash.
+ */
+function ensureTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
+ * Map a query type to the IANA RDAP bootstrap registry file name.
+ */
+function bootstrapFileForType(type: WhoisQueryType): string {
+	switch (type) {
+		case "ipv4":
+			return "ipv4.json";
+		case "ipv6":
+			return "ipv6.json";
+		case "asn":
+			return "asn.json";
+		default:
+			return "dns.json";
+	}
+}
+
+/**
+ * Map a query type to the RDAP path segment used to look it up.
+ */
+function rdapPathForType(type: WhoisQueryType): string {
+	switch (type) {
+		case "ipv4":
+		case "ipv6":
+			return "ip";
+		case "asn":
+			return "autnum";
+		default:
+			return "domain";
+	}
+}
+
+/**
+ * Build the fetch options used for RDAP requests, including the cache instance
+ * when caching is enabled.
+ */
+function buildFetchOptions(
+	headers: Record<string, string> | undefined,
+	cache: Cacheable | undefined,
+): FetchOptions {
+	const fetchOptions: FetchOptions = {
+		headers: { accept: "application/rdap+json", ...headers },
+		// Bootstrap files and RDAP responses are cached by key regardless of the
+		// server's HTTP cache directives, matching the explicit result caching.
+		httpCachePolicy: false,
+	};
+	if (cache) {
+		fetchOptions.cache = cache;
+	}
+	return fetchOptions;
+}
+
+/**
+ * Convert an IPv6 address (including `::` compression) to a BigInt.
+ */
+function ipv6ToBigInt(ip: string): bigint {
+	const [head, tail] = ip.split("::");
+	const headParts = head ? head.split(":") : [];
+	const tailParts = tail ? tail.split(":") : [];
+	const missing = 8 - headParts.length - tailParts.length;
+	const parts = [...headParts, ...Array(missing).fill("0"), ...tailParts];
+	return parts.reduce(
+		(accumulator, part) =>
+			(accumulator << 16n) + BigInt(Number.parseInt(part, 16)),
+		0n,
+	);
+}
+
+/**
+ * Convert an IP address to a BigInt for range comparison.
+ */
+function ipToBigInt(ip: string, type: WhoisQueryType): bigint {
+	if (type === "ipv4") {
+		return ip
+			.split(".")
+			.reduce(
+				(accumulator, part) => (accumulator << 8n) + BigInt(Number(part)),
+				0n,
+			);
+	}
+	return ipv6ToBigInt(ip);
+}
+
+/**
+ * Determine whether an IP address falls within a CIDR block.
+ */
+function ipInCidr(ip: string, cidr: string, type: WhoisQueryType): boolean {
+	const [network, prefixString] = cidr.split("/");
+	const bits = type === "ipv4" ? 32 : 128;
+	const prefix = prefixString ? Number.parseInt(prefixString, 10) : bits;
+	const shift = BigInt(bits - prefix);
+	return ipToBigInt(ip, type) >> shift === ipToBigInt(network, type) >> shift;
+}
+
+/**
+ * Determine whether an ASN falls within an IANA bootstrap range (e.g. `36864-37887`).
+ */
+function asnInRange(asn: number, range: string): boolean {
+	const [startString, endString] = range.split("-");
+	const start = Number.parseInt(startString, 10);
+	const end = endString ? Number.parseInt(endString, 10) : start;
+	return asn >= start && asn <= end;
+}
+
+/**
+ * Determine whether a bootstrap service's keys match the query.
+ */
+function matchesService(
+	type: WhoisQueryType,
+	normalized: string,
+	keys: string[],
+): boolean {
+	if (type === "domain") {
+		const tld = normalized.slice(normalized.lastIndexOf(".") + 1);
+		return keys.some((key) => key.toLowerCase() === tld);
+	}
+	if (type === "asn") {
+		const asn = Number.parseInt(normalized.replace(/^as/i, ""), 10);
+		return keys.some((range) => asnInRange(asn, range));
+	}
+	return keys.some((cidr) => ipInCidr(normalized, cidr, type));
+}
+
+/**
+ * Find the RDAP base URL for a query within a bootstrap registry. The first URL
+ * advertised for the matching service is used (IANA lists the preferred HTTPS
+ * endpoint first).
+ */
+function findRdapBase(
+	bootstrap: RdapBootstrap,
+	type: WhoisQueryType,
+	normalized: string,
+): string | undefined {
+	for (const [keys, urls] of bootstrap.services) {
+		if (matchesService(type, normalized, keys)) {
+			return urls[0];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the RDAP base URL for a query, using an explicit override or a (cached)
+ * IANA bootstrap lookup.
+ */
+async function resolveRdapBase(
+	normalized: string,
+	type: WhoisQueryType,
+	options: RdapOptions,
+	cache: Cacheable | undefined,
+): Promise<string> {
+	if (options.server !== undefined) {
+		return options.server;
+	}
+
+	/* v8 ignore next -- @preserve the real IANA default is only used off the test harness */
+	const base = trimTrailingSlash(options.bootstrapUrl ?? IANA_RDAP_BOOTSTRAP);
+	const url = `${base}/${bootstrapFileForType(type)}`;
+	const response = await fetch(url, buildFetchOptions(options.headers, cache));
+	const bootstrap = JSON.parse(await response.text()) as RdapBootstrap;
+
+	const rdapBase = findRdapBase(bootstrap, type, normalized);
+	if (rdapBase === undefined) {
+		throw new Error(`No RDAP server found for "${normalized}"`);
+	}
+	return rdapBase;
+}
+
+/**
+ * Run the full RDAP pipeline: resolve the base URL, query the endpoint, and parse
+ * the JSON response.
+ */
+async function runRdap(
+	normalized: string,
+	type: WhoisQueryType,
+	options: RdapOptions,
+	cache: Cacheable | undefined,
+): Promise<RdapResult> {
+	const base = await resolveRdapBase(normalized, type, options, cache);
+	const key = type === "asn" ? normalized.replace(/^as/i, "") : normalized;
+	const url = `${ensureTrailingSlash(base)}${rdapPathForType(type)}/${key}`;
+
+	const response = await fetch(url, buildFetchOptions(options.headers, cache));
+	const raw = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`RDAP query for "${normalized}" failed with status ${response.status}`,
+		);
+	}
+
+	let data: Record<string, unknown>;
+	try {
+		data = JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		throw new Error(`RDAP response for "${normalized}" was not valid JSON`);
+	}
+
+	return { query: normalized, type, server: base, raw, data };
+}
+
+/**
+ * Perform an RDAP lookup for a domain, IP address, or ASN and return both the raw
+ * JSON text and the parsed object. The RDAP server is discovered dynamically
+ * through the IANA bootstrap registries (fetched through the package's cached
+ * fetch). When a cache is provided, results are cached and concurrent identical
+ * lookups are coalesced.
+ *
+ * @param {string} query The domain, URL, IP address, or ASN to look up.
+ * @param {RdapOptions} options Optional lookup options.
+ * @returns {Promise<RdapResult>} The raw JSON text and parsed data.
+ */
+export async function rdap(
+	query: string,
+	options: RdapOptions = {},
+): Promise<RdapResult> {
+	const normalized = normalizeWhoisQuery(query);
+	const type = detectQueryType(normalized);
+	const cache = options.caching === false ? undefined : options.cache;
+
+	if (!cache) {
+		return runRdap(normalized, type, options, undefined);
+	}
+
+	const cacheKey = `rdap:${normalized}`;
+
+	return coalesceAsync(`net:${cacheKey}`, async () => {
+		const existing = await cache.get<RdapResult>(cacheKey);
+		if (existing) {
+			return existing;
+		}
+
+		const result = await runRdap(normalized, type, options, cache);
+		await cache.set(cacheKey, result, options.ttl);
+		return result;
+	});
+}

--- a/packages/net/src/rdap.ts
+++ b/packages/net/src/rdap.ts
@@ -236,7 +236,9 @@ async function resolveRdapBase(
 	/* v8 ignore next -- @preserve the real IANA default is only used off the test harness */
 	const base = trimTrailingSlash(options.bootstrapUrl ?? IANA_RDAP_BOOTSTRAP);
 	const url = `${base}/${bootstrapFileForType(type)}`;
-	const response = await fetch(url, buildFetchOptions(options.headers, cache));
+	// Do not forward caller headers (e.g. Authorization for a registry) to the
+	// public IANA bootstrap endpoint.
+	const response = await fetch(url, buildFetchOptions(undefined, cache));
 	if (!response.ok) {
 		throw new Error(
 			`Failed to fetch RDAP bootstrap from ${url}: ${response.status} ${response.statusText}`,
@@ -265,7 +267,13 @@ async function runRdap(
 	const key = type === "asn" ? normalized.replace(/^as/i, "") : normalized;
 	const url = `${ensureTrailingSlash(base)}${rdapPathForType(type)}/${key}`;
 
-	const response = await fetch(url, buildFetchOptions(options.headers, cache));
+	// The RDAP result is cached at the rdap:<query> level with the requested TTL,
+	// so the final query is not cached again at the fetch layer (which would
+	// persist a GET:<url> entry that can outlive and bypass that TTL).
+	const response = await fetch(
+		url,
+		buildFetchOptions(options.headers, undefined),
+	);
 	const raw = await response.text();
 	if (!response.ok) {
 		throw new Error(
@@ -306,7 +314,13 @@ export async function rdap(
 		return runRdap(normalized, type, options, undefined);
 	}
 
-	const cacheKey = `rdap:${normalized}`;
+	// Include every option that changes the result so a lookup against one
+	// server/bootstrap/headers never serves a cache hit meant for another.
+	const cacheKey = `rdap:${normalized}:${JSON.stringify({
+		server: options.server,
+		bootstrapUrl: options.bootstrapUrl,
+		headers: options.headers,
+	})}`;
 
 	return coalesceAsync(`net:${cacheKey}`, async () => {
 		const existing = await cache.get<RdapResult>(cacheKey);

--- a/packages/net/src/whois.ts
+++ b/packages/net/src/whois.ts
@@ -231,6 +231,18 @@ export function normalizeWhoisQuery(input: string): string {
 	value = value.replace(/^www\./, "");
 	// Cut everything from the first path, query, or hash separator.
 	value = value.split(/[/?#]/)[0];
+
+	// Strip an authority port (e.g. "example.com:8443"). An IPv6 literal has
+	// multiple colons, so only strip when there is exactly one colon followed
+	// by digits.
+	const colonIndex = value.indexOf(":");
+	if (colonIndex !== -1 && value.indexOf(":", colonIndex + 1) === -1) {
+		const portPart = value.slice(colonIndex + 1);
+		if (portPart.length > 0 && /^\d+$/.test(portPart)) {
+			value = value.slice(0, colonIndex);
+		}
+	}
+
 	// Strip trailing dots (FQDN root) without a backtracking regex, then trim.
 	while (value.endsWith(".")) {
 		value = value.slice(0, -1);
@@ -258,7 +270,9 @@ export function normalizeWhoisQuery(input: string): string {
  * @returns {WhoisQueryType} The detected query type.
  */
 export function detectQueryType(value: string): WhoisQueryType {
-	if (/^as\d+$/i.test(value)) {
+	// "AS15169" or a bare autonomous system number like "15169" (a value made up
+	// only of digits is neither a domain nor an IP address).
+	if (/^as\d+$/i.test(value) || /^\d+$/.test(value)) {
 		return "asn";
 	}
 	if (isIPv4(value)) {
@@ -544,8 +558,17 @@ export async function whois(
 		return runWhois(normalized, type, effectiveOptions);
 	}
 
-	const followDepth = resolveFollowDepth(options.follow);
-	const cacheKey = `whois:${normalized}:f${followDepth}`;
+	// Include every option that changes the result so a lookup against one
+	// server/config never serves a cache hit meant for another.
+	const cacheKey = `whois:${normalized}:${JSON.stringify({
+		follow: resolveFollowDepth(options.follow),
+		server: options.server,
+		port: options.port,
+		bootstrapServer: options.bootstrapServer,
+		bootstrapPort: options.bootstrapPort,
+		queryPrefix: options.queryPrefix,
+		encoding: options.encoding,
+	})}`;
 
 	return coalesceAsync(`net:${cacheKey}`, async () => {
 		const existing = await cache.get<WhoisResult>(cacheKey);

--- a/packages/net/src/whois.ts
+++ b/packages/net/src/whois.ts
@@ -231,8 +231,11 @@ export function normalizeWhoisQuery(input: string): string {
 	value = value.replace(/^www\./, "");
 	// Cut everything from the first path, query, or hash separator.
 	value = value.split(/[/?#]/)[0];
-	// Strip trailing dots (FQDN root) and surrounding whitespace.
-	value = value.replace(/\.+$/, "").trim();
+	// Strip trailing dots (FQDN root) without a backtracking regex, then trim.
+	while (value.endsWith(".")) {
+		value = value.slice(0, -1);
+	}
+	value = value.trim();
 
 	// Convert internationalized domain names to punycode. domainToASCII returns
 	// "" for invalid input, so fall back to the cleaned value when that happens.
@@ -275,7 +278,10 @@ export function detectQueryType(value: string): WhoisQueryType {
  * @returns {WhoisFields} The parsed fields.
  */
 export function parseWhois(raw: string): WhoisFields {
-	const fields: WhoisFields = {};
+	// Use a null-prototype object so untrusted keys (e.g. "__proto__",
+	// "constructor") cannot pollute the prototype chain and inherited members
+	// (e.g. "toString") never interfere with field lookups.
+	const fields: WhoisFields = Object.create(null);
 
 	for (const line of raw.split(/\r?\n/)) {
 		const trimmed = line.trim();
@@ -344,7 +350,9 @@ function parseReferralValue(value: string): ServerRef | undefined {
 
 	const port =
 		portString === undefined ? WHOIS_PORT : Number.parseInt(portString, 10);
-	return { host, port };
+	// Guard against a non-numeric port (e.g. "host:abc") which would make
+	// createConnection throw; fall back to the default WHOIS port.
+	return { host, port: Number.isNaN(port) ? WHOIS_PORT : port };
 }
 
 /**
@@ -497,7 +505,7 @@ async function runWhois(
 		next = referral;
 	}
 
-	const mergedFields: WhoisFields = {};
+	const mergedFields: WhoisFields = Object.create(null);
 	for (const hop of hops) {
 		mergeFields(mergedFields, hop.fields);
 	}

--- a/packages/net/src/whois.ts
+++ b/packages/net/src/whois.ts
@@ -1,0 +1,567 @@
+import { createConnection, isIPv4, isIPv6 } from "node:net";
+import { domainToASCII } from "node:url";
+import { coalesceAsync } from "@cacheable/utils";
+import type { Cacheable } from "cacheable";
+
+/**
+ * The default WHOIS port as defined by RFC 3912.
+ */
+const WHOIS_PORT = 43;
+
+/**
+ * The IANA WHOIS server used to bootstrap discovery of the authoritative
+ * registry / RIR server for any domain, IP address, or ASN.
+ */
+const IANA_WHOIS_SERVER = "whois.iana.org";
+
+/**
+ * The default socket timeout in milliseconds.
+ */
+const DEFAULT_TIMEOUT = 10_000;
+
+/**
+ * The default number of registry → registrar referral hops to follow.
+ */
+const DEFAULT_FOLLOW_DEPTH = 2;
+
+/**
+ * Line prefixes that mark a comment / disclaimer in WHOIS output and should be
+ * skipped when parsing key/value fields (IANA `%`, ICANN `>>>`, etc.).
+ */
+const COMMENT_PREFIXES = ["%", "#", ">>>", "*"];
+
+/**
+ * Field names (case-insensitive) that carry a referral to another WHOIS server,
+ * in priority order. The first one present in a response is followed.
+ */
+const REFERRAL_KEYS = [
+	"refer",
+	"whois",
+	"registrar whois server",
+	"referralserver",
+];
+
+/**
+ * The detected category of a WHOIS query.
+ */
+export type WhoisQueryType = "domain" | "ipv4" | "ipv6" | "asn";
+
+/**
+ * A resolved WHOIS server reference (host and port).
+ */
+type ServerRef = { host: string; port: number };
+
+/**
+ * Parsed WHOIS fields. Repeated keys (e.g. multiple `Name Server` lines) are
+ * grouped into an array; single occurrences remain a string.
+ */
+export type WhoisFields = Record<string, string | string[]>;
+
+/**
+ * A single server response collected while resolving a WHOIS query. When
+ * referrals are followed there will be one hop per server queried.
+ */
+export type WhoisHop = {
+	/** The server queried for this hop. */
+	server: string;
+	/** The TCP port used for this hop. */
+	port: number;
+	/** The raw text returned by this server. */
+	raw: string;
+	/** The parsed key/value fields for this hop. */
+	fields: WhoisFields;
+};
+
+/**
+ * The result of a WHOIS lookup, exposing both the raw text and parsed JSON.
+ */
+export type WhoisResult = {
+	/** The normalized query that was looked up. */
+	query: string;
+	/** The detected type of the query. */
+	type: WhoisQueryType;
+	/** The final authoritative server that produced the primary data. */
+	server: string;
+	/** The raw text across all hops, separated by a blank line. */
+	raw: string;
+	/** The merged parsed fields across all hops (repeats become arrays). */
+	fields: WhoisFields;
+	/** Every server response, in the order they were queried. */
+	hops: WhoisHop[];
+};
+
+/**
+ * Options for {@link queryWhoisServer}.
+ */
+export type QueryWhoisServerOptions = {
+	/** The server hostname or IP to connect to. */
+	host: string;
+	/** The TCP port to connect to. @default 43 */
+	port?: number;
+	/** The query string written to the socket. */
+	query: string;
+	/** An optional prefix written before the query (e.g. `"domain "`). @default "" */
+	queryPrefix?: string;
+	/** Milliseconds before the socket is destroyed and the call rejects. @default 10000 */
+	timeout?: number;
+	/** The encoding used to decode the response. @default "utf8" */
+	encoding?: BufferEncoding;
+};
+
+/**
+ * Options for {@link whois} and {@link whoisRaw}.
+ */
+export type WhoisOptions = {
+	/**
+	 * Override the WHOIS server to query first. When set, the IANA bootstrap
+	 * step is skipped and this server is queried directly.
+	 */
+	server?: string;
+	/** The TCP port to use for the initial server. @default 43 */
+	port?: number;
+	/** The socket timeout in milliseconds. @default 10000 */
+	timeout?: number;
+	/**
+	 * Whether to follow registry → registrar referrals.
+	 * - `false` / `0`: do not follow (authoritative server only)
+	 * - `true`: follow up to the default depth (2)
+	 * - `number`: follow up to N referral hops
+	 * @default true
+	 */
+	follow?: boolean | number;
+	/** An optional prefix written before the query (e.g. `"domain "`). @default "" */
+	queryPrefix?: string;
+	/** The encoding used to decode responses. @default "utf8" */
+	encoding?: BufferEncoding;
+	/** The bootstrap WHOIS server used when no `server` is provided. @default "whois.iana.org" */
+	bootstrapServer?: string;
+	/** The TCP port of the bootstrap WHOIS server. @default 43 */
+	bootstrapPort?: number;
+	/**
+	 * Enable or disable caching for this lookup. When `false`, no caching is
+	 * performed even if a cache is available. @default true (when a cache is available)
+	 */
+	caching?: boolean;
+	/** The cache instance. The standalone {@link whois} caches only when this is provided. */
+	cache?: Cacheable;
+	/** An optional TTL override for cached results (milliseconds or shorthand). */
+	ttl?: number | string;
+};
+
+/**
+ * Open a raw WHOIS connection to a single server on TCP port 43, write the
+ * query, and resolve with the full text response. This is the low-level
+ * primitive used by {@link whois}; host and port are explicit so it can be
+ * pointed at any server (including a local test server).
+ *
+ * @param {QueryWhoisServerOptions} options The connection and query options.
+ * @returns {Promise<string>} The raw text returned by the server.
+ */
+export function queryWhoisServer(
+	options: QueryWhoisServerOptions,
+): Promise<string> {
+	const {
+		host,
+		port = WHOIS_PORT,
+		query,
+		queryPrefix = "",
+		timeout = DEFAULT_TIMEOUT,
+		encoding = "utf8",
+	} = options;
+
+	return new Promise<string>((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		let settled = false;
+
+		const socket = createConnection({ host, port });
+		socket.setTimeout(timeout);
+
+		// Settle exactly once. Timeout/error/close can all fire for one socket, so
+		// the guard prevents a double resolve/reject (and an unhandled rejection).
+		const settle = (finish: () => void) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			socket.destroy();
+			finish();
+		};
+
+		socket.on("connect", () => {
+			socket.write(`${queryPrefix}${query}\r\n`);
+		});
+
+		socket.on("data", (chunk: Buffer) => {
+			chunks.push(chunk);
+		});
+
+		socket.on("timeout", () => {
+			settle(() =>
+				reject(
+					new Error(
+						`WHOIS query to ${host}:${port} timed out after ${timeout}ms`,
+					),
+				),
+			);
+		});
+
+		socket.on("error", (error: Error) => {
+			settle(() => reject(error));
+		});
+
+		socket.on("close", () => {
+			settle(() => resolve(Buffer.concat(chunks).toString(encoding)));
+		});
+	});
+}
+
+/**
+ * Normalize a WHOIS query by stripping URL scheme, `www.`, path/query/hash, and
+ * trailing dots, lowercasing, and converting internationalized domains to
+ * punycode.
+ *
+ * @param {string} input The raw query (domain, URL, IP, or ASN).
+ * @returns {string} The normalized query.
+ */
+export function normalizeWhoisQuery(input: string): string {
+	let value = input.trim().toLowerCase();
+	// Strip a leading scheme such as http://, https://, or whois://.
+	value = value.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+	// Strip a leading www. prefix.
+	value = value.replace(/^www\./, "");
+	// Cut everything from the first path, query, or hash separator.
+	value = value.split(/[/?#]/)[0];
+	// Strip trailing dots (FQDN root) and surrounding whitespace.
+	value = value.replace(/\.+$/, "").trim();
+
+	// Convert internationalized domain names to punycode. domainToASCII returns
+	// "" for invalid input, so fall back to the cleaned value when that happens.
+	const hasNonAscii = [...value].some((char) => char.charCodeAt(0) > 127);
+	if (hasNonAscii) {
+		const ascii = domainToASCII(value);
+		if (ascii !== "") {
+			value = ascii;
+		}
+	}
+
+	return value;
+}
+
+/**
+ * Detect whether a normalized query is a domain, IPv4 address, IPv6 address, or
+ * autonomous system number.
+ *
+ * @param {string} value The normalized query.
+ * @returns {WhoisQueryType} The detected query type.
+ */
+export function detectQueryType(value: string): WhoisQueryType {
+	if (/^as\d+$/i.test(value)) {
+		return "asn";
+	}
+	if (isIPv4(value)) {
+		return "ipv4";
+	}
+	if (isIPv6(value)) {
+		return "ipv6";
+	}
+	return "domain";
+}
+
+/**
+ * Parse raw WHOIS text into a key/value object. Comment and disclaimer lines are
+ * ignored, and repeated keys are grouped into arrays.
+ *
+ * @param {string} raw The raw WHOIS text.
+ * @returns {WhoisFields} The parsed fields.
+ */
+export function parseWhois(raw: string): WhoisFields {
+	const fields: WhoisFields = {};
+
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (trimmed === "") {
+			continue;
+		}
+		if (COMMENT_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+			continue;
+		}
+
+		const index = trimmed.indexOf(":");
+		if (index === -1) {
+			continue;
+		}
+
+		const key = trimmed.slice(0, index).trim();
+		const value = trimmed.slice(index + 1).trim();
+		if (key === "" || value === "") {
+			continue;
+		}
+
+		const existing = fields[key];
+		if (existing === undefined) {
+			fields[key] = value;
+		} else if (Array.isArray(existing)) {
+			existing.push(value);
+		} else {
+			fields[key] = [existing, value];
+		}
+	}
+
+	return fields;
+}
+
+/**
+ * Look up a field by name, ignoring case, returning the first value.
+ */
+function getFieldCaseInsensitive(
+	fields: WhoisFields,
+	name: string,
+): string | undefined {
+	const lower = name.toLowerCase();
+	for (const [key, value] of Object.entries(fields)) {
+		if (key.toLowerCase() === lower) {
+			return Array.isArray(value) ? value[0] : value;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Parse a referral value (e.g. `whois.example.com`, `whois://host:43`) into a
+ * host and port.
+ */
+function parseReferralValue(value: string): ServerRef | undefined {
+	// Strip a scheme such as whois:// or rwhois:// and any trailing path.
+	const cleaned = value
+		.trim()
+		.replace(/^[a-z]+:\/\//i, "")
+		.split(/[/\s]/)[0];
+
+	const [host, portString] = cleaned.split(":");
+	if (host === "") {
+		return undefined;
+	}
+
+	const port =
+		portString === undefined ? WHOIS_PORT : Number.parseInt(portString, 10);
+	return { host, port };
+}
+
+/**
+ * Extract the first referral server from a parsed response, if any.
+ */
+function extractReferral(fields: WhoisFields): ServerRef | undefined {
+	for (const key of REFERRAL_KEYS) {
+		const value = getFieldCaseInsensitive(fields, key);
+		if (value !== undefined) {
+			return parseReferralValue(value);
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Merge the fields of one hop into an accumulator, grouping repeated keys into
+ * arrays so no data is lost across hops.
+ */
+function mergeFields(target: WhoisFields, source: WhoisFields): void {
+	for (const [key, value] of Object.entries(source)) {
+		const existing = target[key];
+		if (existing === undefined) {
+			target[key] = value;
+			continue;
+		}
+
+		const base = Array.isArray(existing) ? existing : [existing];
+		const incoming = Array.isArray(value) ? value : [value];
+		target[key] = [...base, ...incoming];
+	}
+}
+
+/**
+ * Resolve the configured follow option into a concrete referral depth.
+ */
+function resolveFollowDepth(follow: WhoisOptions["follow"]): number {
+	if (follow === undefined || follow === true) {
+		return DEFAULT_FOLLOW_DEPTH;
+	}
+	if (follow === false) {
+		return 0;
+	}
+	return follow;
+}
+
+/**
+ * Build the cache key used to remember which server is authoritative for a query.
+ */
+function serverCacheKey(normalized: string, type: WhoisQueryType): string {
+	if (type === "domain") {
+		const tld = normalized.slice(normalized.lastIndexOf(".") + 1);
+		return `whois:server:${tld}`;
+	}
+	return `whois:server:${type}:${normalized}`;
+}
+
+/**
+ * Resolve the first server to query for a normalized query, using (in order) an
+ * explicit override, the cached mapping, or a live IANA bootstrap lookup.
+ */
+async function resolveBootstrapServer(
+	normalized: string,
+	type: WhoisQueryType,
+	options: WhoisOptions,
+): Promise<ServerRef> {
+	if (options.server !== undefined) {
+		return { host: options.server, port: options.port ?? WHOIS_PORT };
+	}
+
+	const cache = options.cache;
+	const key = serverCacheKey(normalized, type);
+
+	if (cache) {
+		const cached = await cache.get<ServerRef>(key);
+		if (cached) {
+			return cached;
+		}
+	}
+
+	const ianaRaw = await queryWhoisServer({
+		/* v8 ignore next -- @preserve the real IANA host is only used off the test harness */
+		host: options.bootstrapServer ?? IANA_WHOIS_SERVER,
+		port: options.bootstrapPort ?? WHOIS_PORT,
+		query: normalized,
+		timeout: options.timeout,
+		encoding: options.encoding,
+	});
+
+	const refer = getFieldCaseInsensitive(parseWhois(ianaRaw), "refer");
+	const referral = refer === undefined ? undefined : parseReferralValue(refer);
+	if (referral === undefined) {
+		throw new Error(`No WHOIS server found for "${normalized}" via IANA`);
+	}
+
+	if (cache) {
+		await cache.set(key, referral);
+	}
+
+	return referral;
+}
+
+/**
+ * Run the full WHOIS pipeline: resolve the authoritative server, query it,
+ * follow referrals up to the configured depth, and combine the results.
+ */
+async function runWhois(
+	normalized: string,
+	type: WhoisQueryType,
+	options: WhoisOptions,
+): Promise<WhoisResult> {
+	let remaining = resolveFollowDepth(options.follow);
+	const visited = new Set<string>();
+	const hops: WhoisHop[] = [];
+
+	let next: ServerRef | undefined = await resolveBootstrapServer(
+		normalized,
+		type,
+		options,
+	);
+
+	while (next !== undefined) {
+		const id = `${next.host.toLowerCase()}:${next.port}`;
+		if (visited.has(id)) {
+			break;
+		}
+		visited.add(id);
+
+		const raw = await queryWhoisServer({
+			host: next.host,
+			port: next.port,
+			query: normalized,
+			queryPrefix: options.queryPrefix,
+			timeout: options.timeout,
+			encoding: options.encoding,
+		});
+		const fields = parseWhois(raw);
+		hops.push({ server: next.host, port: next.port, raw, fields });
+
+		if (remaining <= 0) {
+			break;
+		}
+
+		const referral = extractReferral(fields);
+		if (referral === undefined) {
+			break;
+		}
+
+		remaining -= 1;
+		next = referral;
+	}
+
+	const mergedFields: WhoisFields = {};
+	for (const hop of hops) {
+		mergeFields(mergedFields, hop.fields);
+	}
+
+	return {
+		query: normalized,
+		type,
+		server: hops[hops.length - 1].server,
+		raw: hops.map((hop) => hop.raw).join("\n\n"),
+		fields: mergedFields,
+		hops,
+	};
+}
+
+/**
+ * Perform a WHOIS lookup for a domain, IP address, or ASN and return both the
+ * raw text and parsed JSON fields. The authoritative server is discovered
+ * dynamically through IANA (and cached), and registry → registrar referrals are
+ * followed by default. When a cache is provided, results are cached and
+ * concurrent identical lookups are coalesced.
+ *
+ * @param {string} query The domain, URL, IP address, or ASN to look up.
+ * @param {WhoisOptions} options Optional lookup options.
+ * @returns {Promise<WhoisResult>} The raw text and parsed fields.
+ */
+export async function whois(
+	query: string,
+	options: WhoisOptions = {},
+): Promise<WhoisResult> {
+	const normalized = normalizeWhoisQuery(query);
+	const type = detectQueryType(normalized);
+	const cache = options.caching === false ? undefined : options.cache;
+	const effectiveOptions: WhoisOptions = { ...options, cache };
+
+	if (!cache) {
+		return runWhois(normalized, type, effectiveOptions);
+	}
+
+	const followDepth = resolveFollowDepth(options.follow);
+	const cacheKey = `whois:${normalized}:f${followDepth}`;
+
+	return coalesceAsync(`net:${cacheKey}`, async () => {
+		const existing = await cache.get<WhoisResult>(cacheKey);
+		if (existing) {
+			return existing;
+		}
+
+		const result = await runWhois(normalized, type, effectiveOptions);
+		await cache.set(cacheKey, result, options.ttl);
+		return result;
+	});
+}
+
+/**
+ * Perform a WHOIS lookup and return only the raw text response.
+ *
+ * @param {string} query The domain, URL, IP address, or ASN to look up.
+ * @param {WhoisOptions} options Optional lookup options.
+ * @returns {Promise<string>} The raw WHOIS text.
+ */
+export async function whoisRaw(
+	query: string,
+	options?: WhoisOptions,
+): Promise<string> {
+	const result = await whois(query, options);
+	return result.raw;
+}

--- a/packages/net/test/rdap.test.ts
+++ b/packages/net/test/rdap.test.ts
@@ -130,6 +130,12 @@ describe("rdap lookups", () => {
 		);
 	});
 
+	test("throws when the bootstrap registry cannot be fetched", async () => {
+		await expect(
+			rdap("foo.test", { bootstrapUrl: `${origin}/missing-bootstrap` }),
+		).rejects.toThrow(/Failed to fetch RDAP bootstrap/);
+	});
+
 	test("uses an explicit server (without a trailing slash) and skips the bootstrap", async () => {
 		const before = countRequests("/rdap/dns.json");
 		const result = await rdap("skip.test", {

--- a/packages/net/test/rdap.test.ts
+++ b/packages/net/test/rdap.test.ts
@@ -8,6 +8,7 @@ let server: http.Server;
 let origin = "";
 let bootstrapUrl = "";
 const requests: string[] = [];
+const authByPath = new Map<string, string | undefined>();
 
 /** Count how many times a given path has been requested. */
 function countRequests(path: string): number {
@@ -27,6 +28,7 @@ beforeAll(async () => {
 	server = http.createServer((req, res) => {
 		const url = req.url ?? "/";
 		requests.push(url);
+		authByPath.set(url, req.headers.authorization);
 		const rdapBase = `${origin}/rdap-server/`;
 		const other = "https://unused.example/rdap/";
 
@@ -222,6 +224,24 @@ describe("rdap caching", () => {
 		await rdap("free.test", { bootstrapUrl });
 		await rdap("free.test", { bootstrapUrl });
 		expect(countRequests("/rdap-server/domain/free.test")).toBe(2);
+	});
+
+	test("varies the cache key by server/bootstrap so endpoints are not confused", async () => {
+		const cache = new Cacheable();
+		await rdap("keyed.test", { bootstrapUrl, cache });
+		await rdap("keyed.test", { server: `${origin}/rdap-server`, cache });
+		expect(countRequests("/rdap-server/domain/keyed.test")).toBe(2);
+	});
+});
+
+describe("rdap headers", () => {
+	test("does not forward caller headers to the bootstrap registry", async () => {
+		await rdap("hdr.test", {
+			bootstrapUrl,
+			headers: { authorization: "secret" },
+		});
+		expect(authByPath.get("/rdap/dns.json")).toBeUndefined();
+		expect(authByPath.get("/rdap-server/domain/hdr.test")).toBe("secret");
 	});
 });
 

--- a/packages/net/test/rdap.test.ts
+++ b/packages/net/test/rdap.test.ts
@@ -1,0 +1,236 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Cacheable } from "cacheable";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { CacheableNet, rdap } from "../src/index.js";
+
+let server: http.Server;
+let origin = "";
+let bootstrapUrl = "";
+const requests: string[] = [];
+
+/** Count how many times a given path has been requested. */
+function countRequests(path: string): number {
+	return requests.filter((url) => url === path).length;
+}
+
+function sendJson(
+	res: http.ServerResponse,
+	status: number,
+	body: unknown,
+): void {
+	res.writeHead(status, { "content-type": "application/rdap+json" });
+	res.end(JSON.stringify(body));
+}
+
+beforeAll(async () => {
+	server = http.createServer((req, res) => {
+		const url = req.url ?? "/";
+		requests.push(url);
+		const rdapBase = `${origin}/rdap-server/`;
+		const other = "https://unused.example/rdap/";
+
+		if (url === "/rdap/dns.json") {
+			sendJson(res, 200, {
+				services: [
+					[["example"], [other]],
+					[["test"], [rdapBase]],
+				],
+			});
+			return;
+		}
+		if (url === "/rdap/ipv4.json") {
+			sendJson(res, 200, {
+				services: [
+					[["10.0.0.0/8", "127.0.0.0"], [other]],
+					[["1.0.0.0/8"], [rdapBase]],
+				],
+			});
+			return;
+		}
+		if (url === "/rdap/ipv6.json") {
+			sendJson(res, 200, {
+				services: [
+					[["2001:db8::/32"], [rdapBase]],
+					[["::/0"], [rdapBase]],
+				],
+			});
+			return;
+		}
+		if (url === "/rdap/asn.json") {
+			sendJson(res, 200, {
+				services: [
+					[["1-100"], [other]],
+					[["15169"], [rdapBase]],
+				],
+			});
+			return;
+		}
+		if (url === "/rdap-server/domain/missing.test") {
+			sendJson(res, 404, { errorCode: 404 });
+			return;
+		}
+		if (url === "/rdap-server/domain/bad.test") {
+			res.writeHead(200, { "content-type": "application/rdap+json" });
+			res.end("this is not json");
+			return;
+		}
+		if (url.startsWith("/rdap-server/domain/")) {
+			sendJson(res, 200, {
+				objectClassName: "domain",
+				ldhName: url.slice("/rdap-server/domain/".length),
+			});
+			return;
+		}
+		if (url.startsWith("/rdap-server/ip/")) {
+			sendJson(res, 200, { objectClassName: "ip network", handle: "NET-TEST" });
+			return;
+		}
+		if (url.startsWith("/rdap-server/autnum/")) {
+			sendJson(res, 200, {
+				objectClassName: "autnum",
+				handle: url.slice("/rdap-server/autnum/".length),
+			});
+			return;
+		}
+
+		res.writeHead(404);
+		res.end("not found");
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const { port } = server.address() as AddressInfo;
+	origin = `http://127.0.0.1:${port}`;
+	bootstrapUrl = `${origin}/rdap`;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve) => {
+		server.closeAllConnections();
+		server.close(() => resolve());
+	});
+});
+
+describe("rdap lookups", () => {
+	test("looks up a domain through the bootstrap registry", async () => {
+		const result = await rdap("foo.test", { bootstrapUrl });
+		expect(result.query).toBe("foo.test");
+		expect(result.type).toBe("domain");
+		expect(result.server).toBe(`${origin}/rdap-server/`);
+		expect(result.data.objectClassName).toBe("domain");
+		expect(result.data.ldhName).toBe("foo.test");
+		expect(result.raw).toContain("domain");
+	});
+
+	test("throws when the TLD is not in the bootstrap registry", async () => {
+		await expect(rdap("foo.unknown", { bootstrapUrl })).rejects.toThrow(
+			/No RDAP server found/,
+		);
+	});
+
+	test("uses an explicit server (without a trailing slash) and skips the bootstrap", async () => {
+		const before = countRequests("/rdap/dns.json");
+		const result = await rdap("skip.test", {
+			server: `${origin}/rdap-server`,
+		});
+		expect(result.data.objectClassName).toBe("domain");
+		expect(countRequests("/rdap/dns.json")).toBe(before);
+	});
+
+	test("accepts a bootstrap URL with a trailing slash", async () => {
+		const result = await rdap("slash.test", {
+			bootstrapUrl: `${bootstrapUrl}/`,
+		});
+		expect(result.data.objectClassName).toBe("domain");
+		expect(result.data.ldhName).toBe("slash.test");
+	});
+
+	test("looks up an IPv4 address", async () => {
+		const result = await rdap("1.2.3.4", { bootstrapUrl });
+		expect(result.type).toBe("ipv4");
+		expect(result.data.objectClassName).toBe("ip network");
+		expect(countRequests("/rdap-server/ip/1.2.3.4")).toBe(1);
+	});
+
+	test("looks up an IPv6 address (full form)", async () => {
+		const result = await rdap("2001:0db8:0000:0000:0000:0000:0000:0009", {
+			bootstrapUrl,
+		});
+		expect(result.type).toBe("ipv6");
+		expect(result.data.objectClassName).toBe("ip network");
+	});
+
+	test("looks up an IPv6 address (compressed form)", async () => {
+		const result = await rdap("::1234", { bootstrapUrl });
+		expect(result.type).toBe("ipv6");
+		expect(result.data.objectClassName).toBe("ip network");
+	});
+
+	test("looks up an ASN", async () => {
+		const result = await rdap("AS15169", { bootstrapUrl });
+		expect(result.type).toBe("asn");
+		expect(result.data.handle).toBe("15169");
+		expect(countRequests("/rdap-server/autnum/15169")).toBe(1);
+	});
+
+	test("throws when the RDAP query returns a non-ok status", async () => {
+		await expect(rdap("missing.test", { bootstrapUrl })).rejects.toThrow(
+			/status 404/,
+		);
+	});
+
+	test("throws when the RDAP response is not valid JSON", async () => {
+		await expect(rdap("bad.test", { bootstrapUrl })).rejects.toThrow(
+			/not valid JSON/,
+		);
+	});
+});
+
+describe("rdap caching", () => {
+	test("caches results and serves repeats from cache", async () => {
+		const cache = new Cacheable();
+		await rdap("cache.test", { bootstrapUrl, cache });
+		await rdap("cache.test", { bootstrapUrl, cache });
+		expect(countRequests("/rdap-server/domain/cache.test")).toBe(1);
+	});
+
+	test("coalesces concurrent identical lookups", async () => {
+		const cache = new Cacheable();
+		await Promise.all([
+			rdap("coal.test", { bootstrapUrl, cache }),
+			rdap("coal.test", { bootstrapUrl, cache }),
+		]);
+		expect(countRequests("/rdap-server/domain/coal.test")).toBe(1);
+	});
+
+	test("does not cache when caching is disabled", async () => {
+		const cache = new Cacheable();
+		await rdap("nc.test", { bootstrapUrl, cache, caching: false });
+		await rdap("nc.test", { bootstrapUrl, cache, caching: false });
+		expect(countRequests("/rdap-server/domain/nc.test")).toBe(2);
+	});
+
+	test("does not cache without a cache instance", async () => {
+		await rdap("free.test", { bootstrapUrl });
+		await rdap("free.test", { bootstrapUrl });
+		expect(countRequests("/rdap-server/domain/free.test")).toBe(2);
+	});
+});
+
+describe("CacheableNet.rdap", () => {
+	test("uses the instance cache for repeat lookups", async () => {
+		const instance = new CacheableNet();
+		await instance.rdap("inst.test", { bootstrapUrl });
+		await instance.rdap("inst.test", { bootstrapUrl });
+		expect(countRequests("/rdap-server/domain/inst.test")).toBe(1);
+	});
+
+	test("bypasses the cache when caching is false", async () => {
+		const instance = new CacheableNet();
+		await instance.rdap("instnc.test", { bootstrapUrl, caching: false });
+		await instance.rdap("instnc.test", { bootstrapUrl, caching: false });
+		expect(countRequests("/rdap-server/domain/instnc.test")).toBe(2);
+	});
+});

--- a/packages/net/test/whois.test.ts
+++ b/packages/net/test/whois.test.ts
@@ -73,6 +73,7 @@ let silent: Fake;
 let noRefer: Fake;
 let badRefer: Fake;
 let noPortRefer: Fake;
+let badPortRefer: Fake;
 let capture: Fake;
 let idnPort: number;
 
@@ -164,6 +165,13 @@ beforeAll(async () => {
 		[
 			`Domain Name: ${query}`,
 			"Registrar WHOIS Server: nonexistent.invalid",
+			"",
+		].join("\n"),
+	);
+	badPortRefer = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			"Registrar WHOIS Server: nonexistent.invalid:abc",
 			"",
 		].join("\n"),
 	);
@@ -325,6 +333,14 @@ describe("parseWhois", () => {
 		expect(fields.emptyval).toBeUndefined();
 		expect(fields.NoColonLine).toBeUndefined();
 	});
+
+	test("does not pollute the object prototype", () => {
+		const fields = parseWhois(
+			["__proto__: polluted", "constructor: nope", "Domain: ok", ""].join("\n"),
+		);
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(fields.Domain).toBe("ok");
+	});
 });
 
 describe("whois lookups", () => {
@@ -436,6 +452,17 @@ describe("whois lookups", () => {
 			whois("x.test", {
 				server: "127.0.0.1",
 				port: noPortRefer.port,
+				follow: 1,
+				timeout: 2000,
+			}),
+		).rejects.toThrow();
+	});
+
+	test("falls back to the default port for a non-numeric referral port", async () => {
+		await expect(
+			whois("x.test", {
+				server: "127.0.0.1",
+				port: badPortRefer.port,
 				follow: 1,
 				timeout: 2000,
 			}),

--- a/packages/net/test/whois.test.ts
+++ b/packages/net/test/whois.test.ts
@@ -283,6 +283,10 @@ describe("normalizeWhoisQuery", () => {
 		["español.com", "xn--espaol-zwa.com"],
 		["8.8.8.8", "8.8.8.8"],
 		["AS15169", "as15169"],
+		["https://example.com:8443/path", "example.com"],
+		["example.com:abc", "example.com:abc"],
+		["example.com:", "example.com:"],
+		["2001:db8::1", "2001:db8::1"],
 	])("normalizes %s -> %s", (input, expected) => {
 		expect(normalizeWhoisQuery(input)).toBe(expected);
 	});
@@ -299,6 +303,7 @@ describe("detectQueryType", () => {
 		["2001:db8::1", "ipv6"],
 		["as15169", "asn"],
 		["AS15169", "asn"],
+		["15169", "asn"],
 	])("detects %s as %s", (input, expected) => {
 		expect(detectQueryType(input)).toBe(expected);
 	});
@@ -578,6 +583,24 @@ describe("whois caching", () => {
 		});
 		expect(result.type).toBe("ipv4");
 		expect(await cache.get("whois:server:ipv4:8.8.8.8")).toBeDefined();
+	});
+
+	test("varies the cache key by server so different servers are not confused", async () => {
+		const cache = new Cacheable();
+		const a = await whois("keyed.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+			cache,
+		});
+		const b = await whois("keyed.test", {
+			server: "127.0.0.1",
+			port: registrar.port,
+			follow: false,
+			cache,
+		});
+		expect(a.hops[0].port).toBe(counter.port);
+		expect(b.hops[0].port).toBe(registrar.port);
 	});
 
 	test("does not cache failed lookups", async () => {

--- a/packages/net/test/whois.test.ts
+++ b/packages/net/test/whois.test.ts
@@ -1,0 +1,636 @@
+import net, { type AddressInfo } from "node:net";
+import { Cacheable } from "cacheable";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+	CacheableNet,
+	detectQueryType,
+	normalizeWhoisQuery,
+	parseWhois,
+	queryWhoisServer,
+	whois,
+	whoisRaw,
+} from "../src/index.js";
+
+/** Every server started during the suite, closed in afterAll. */
+const allServers: net.Server[] = [];
+/** Every accepted socket, destroyed in afterAll so close() never hangs. */
+const allSockets: net.Socket[] = [];
+
+/** Start a raw TCP server on an ephemeral loopback port. */
+function startServer(
+	onConnection: (socket: net.Socket) => void,
+): Promise<{ server: net.Server; port: number }> {
+	return new Promise((resolve) => {
+		const server = net.createServer(onConnection);
+		server.on("connection", (socket) => allSockets.push(socket));
+		allServers.push(server);
+		server.listen(0, "127.0.0.1", () => {
+			resolve({ server, port: (server.address() as AddressInfo).port });
+		});
+	});
+}
+
+type Fake = {
+	port: number;
+	state: { connections: number; lastRaw: string };
+};
+
+/**
+ * Start a fake WHOIS server that replies with the string returned by `respond`.
+ * Returning undefined leaves the connection open (to exercise timeouts).
+ */
+async function startFakeWhois(
+	respond: (query: string) => string | undefined,
+): Promise<Fake> {
+	const state = { connections: 0, lastRaw: "" };
+	const { port } = await startServer((socket) => {
+		state.connections += 1;
+		let buffer = "";
+		socket.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString("utf8");
+			if (buffer.includes("\n")) {
+				state.lastRaw = buffer;
+				const response = respond(buffer.split(/\r?\n/)[0]);
+				if (response !== undefined) {
+					socket.end(response);
+				}
+			}
+		});
+	});
+	return { port, state };
+}
+
+let iana: Fake;
+let registry: Fake;
+let registrar: Fake;
+let chain1: Fake;
+let chain2: Fake;
+let chain3: Fake;
+let loopA: Fake;
+let loopB: Fake;
+let counter: Fake;
+let silent: Fake;
+let noRefer: Fake;
+let badRefer: Fake;
+let noPortRefer: Fake;
+let capture: Fake;
+let idnPort: number;
+
+beforeAll(async () => {
+	registrar = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			"Registrar: Test Registrar",
+			"Name Server: ns3.registrar.test",
+			"Name Server: ns4.registrar.test",
+			"Registrar Abuse Contact Email: abuse@registrar.test",
+			"",
+		].join("\n"),
+	);
+
+	registry = await startFakeWhois((query) =>
+		[
+			"% IANA-style comment",
+			">>> disclaimer line <<<",
+			"# hash comment",
+			"* star comment",
+			`Domain Name: ${query}`,
+			"Registry Domain ID: 12345",
+			"Name Server: ns1.registry.test",
+			"Name Server: ns2.registry.test",
+			`Registrar WHOIS Server: 127.0.0.1:${registrar.port}`,
+			`Registrar WHOIS Server: 127.0.0.1:${registrar.port}`,
+			"URL: http://www.registry.test",
+			"novalue:",
+			": nokey",
+			"NoColonLineHere",
+			"",
+		].join("\n"),
+	);
+
+	iana = await startFakeWhois((query) =>
+		[
+			"% IANA",
+			`refer: 127.0.0.1:${registry.port}`,
+			`domain: ${query}`,
+			"",
+		].join("\n"),
+	);
+
+	chain3 = await startFakeWhois((query) =>
+		[`Domain Name: ${query}`, "Result: deep", ""].join("\n"),
+	);
+	chain2 = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			`Registrar WHOIS Server: 127.0.0.1:${chain3.port}`,
+			"",
+		].join("\n"),
+	);
+	chain1 = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			`Registrar WHOIS Server: 127.0.0.1:${chain2.port}`,
+			"",
+		].join("\n"),
+	);
+
+	loopA = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			`Registrar WHOIS Server: 127.0.0.1:${loopB.port}`,
+			"",
+		].join("\n"),
+	);
+	loopB = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			`Registrar WHOIS Server: 127.0.0.1:${loopA.port}`,
+			"",
+		].join("\n"),
+	);
+
+	counter = await startFakeWhois((query) =>
+		[`Domain Name: ${query}`, "Status: ok", ""].join("\n"),
+	);
+
+	silent = await startFakeWhois(() => undefined);
+
+	noRefer = await startFakeWhois((query) =>
+		["% iana", `domain: ${query}`, ""].join("\n"),
+	);
+	badRefer = await startFakeWhois(() => "refer: whois://\n");
+	noPortRefer = await startFakeWhois((query) =>
+		[
+			`Domain Name: ${query}`,
+			"Registrar WHOIS Server: nonexistent.invalid",
+			"",
+		].join("\n"),
+	);
+
+	capture = await startFakeWhois(() => "Received: ok\n");
+
+	const idn = await startServer((socket) => {
+		socket.on("data", () => {
+			const payload = Buffer.from("Domain Name: café.test\n", "utf8");
+			const splitAt = payload.indexOf(0xc3) + 1;
+			socket.write(payload.subarray(0, splitAt));
+			setImmediate(() => {
+				socket.write(payload.subarray(splitAt));
+				socket.end();
+			});
+		});
+	});
+	idnPort = idn.port;
+});
+
+afterAll(async () => {
+	for (const socket of allSockets) {
+		socket.destroy();
+	}
+	await Promise.all(
+		allServers.map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe("queryWhoisServer", () => {
+	test("connects and returns the raw response", async () => {
+		const raw = await queryWhoisServer({
+			host: "127.0.0.1",
+			port: counter.port,
+			query: "x.test",
+		});
+		expect(raw).toContain("Domain Name: x.test");
+	});
+
+	test("writes the query with prefix and CRLF", async () => {
+		await queryWhoisServer({
+			host: "127.0.0.1",
+			port: capture.port,
+			query: "example.com",
+			queryPrefix: "domain ",
+		});
+		expect(capture.state.lastRaw).toBe("domain example.com\r\n");
+	});
+
+	test("rejects on timeout", async () => {
+		await expect(
+			queryWhoisServer({
+				host: "127.0.0.1",
+				port: silent.port,
+				query: "x",
+				timeout: 150,
+			}),
+		).rejects.toThrow(/timed out/);
+	});
+
+	test("rejects when the connection is refused", async () => {
+		const temp = net.createServer();
+		await new Promise<void>((resolve) => {
+			temp.listen(0, "127.0.0.1", () => resolve());
+		});
+		const closedPort = (temp.address() as AddressInfo).port;
+		await new Promise<void>((resolve) => temp.close(() => resolve()));
+
+		await expect(
+			queryWhoisServer({
+				host: "127.0.0.1",
+				port: closedPort,
+				query: "x",
+				timeout: 2000,
+			}),
+		).rejects.toThrow();
+	});
+
+	test("decodes multi-byte responses split across chunks", async () => {
+		const raw = await queryWhoisServer({
+			host: "127.0.0.1",
+			port: idnPort,
+			query: "x",
+		});
+		expect(raw).toContain("café.test");
+	});
+
+	test("defaults to the WHOIS port when none is given", async () => {
+		// Nothing listens on port 43 here, so this exercises the default-port path
+		// and rejects (connection refused or timeout).
+		await expect(
+			queryWhoisServer({ host: "127.0.0.1", query: "x", timeout: 1000 }),
+		).rejects.toThrow();
+	});
+});
+
+describe("normalizeWhoisQuery", () => {
+	test.each([
+		["https://www.Example.COM/path?q=1#h", "example.com"],
+		["HTTP://Example.com/", "example.com"],
+		["whois://host.test", "host.test"],
+		["  example.com.  ", "example.com"],
+		["example.com", "example.com"],
+		["español.com", "xn--espaol-zwa.com"],
+		["8.8.8.8", "8.8.8.8"],
+		["AS15169", "as15169"],
+	])("normalizes %s -> %s", (input, expected) => {
+		expect(normalizeWhoisQuery(input)).toBe(expected);
+	});
+
+	test("keeps the original value when the IDN is invalid", () => {
+		expect(normalizeWhoisQuery("￿")).toBe("￿");
+	});
+});
+
+describe("detectQueryType", () => {
+	test.each([
+		["example.com", "domain"],
+		["8.8.8.8", "ipv4"],
+		["2001:db8::1", "ipv6"],
+		["as15169", "asn"],
+		["AS15169", "asn"],
+	])("detects %s as %s", (input, expected) => {
+		expect(detectQueryType(input)).toBe(expected);
+	});
+});
+
+describe("parseWhois", () => {
+	test("parses fields, ignoring comments and grouping repeats", () => {
+		const raw = [
+			"% comment",
+			"# hash",
+			">>> disclaimer",
+			"* star",
+			"Domain Name: example.com",
+			"Name Server: ns1.example.com",
+			"Name Server: ns2.example.com",
+			"Name Server: ns3.example.com",
+			"URL: http://example.com/path",
+			"emptyval:",
+			": emptykey",
+			"NoColonLine",
+			"",
+		].join("\r\n");
+
+		const fields = parseWhois(raw);
+		expect(fields["Domain Name"]).toBe("example.com");
+		expect(fields["Name Server"]).toEqual([
+			"ns1.example.com",
+			"ns2.example.com",
+			"ns3.example.com",
+		]);
+		expect(fields.URL).toBe("http://example.com/path");
+		expect(fields.emptyval).toBeUndefined();
+		expect(fields.NoColonLine).toBeUndefined();
+	});
+});
+
+describe("whois lookups", () => {
+	test("looks up via an explicit server without following", async () => {
+		const result = await whois("example.test", {
+			server: "127.0.0.1",
+			port: registry.port,
+			follow: false,
+		});
+		expect(result.type).toBe("domain");
+		expect(result.hops).toHaveLength(1);
+		expect(result.server).toBe("127.0.0.1");
+		expect(result.fields["Name Server"]).toEqual([
+			"ns1.registry.test",
+			"ns2.registry.test",
+		]);
+		expect(result.fields["Registrar Abuse Contact Email"]).toBeUndefined();
+		expect(result.raw).toContain("Domain Name: example.test");
+	});
+
+	test("follows registry -> registrar referrals by default", async () => {
+		const result = await whois("example.test", {
+			server: "127.0.0.1",
+			port: registry.port,
+		});
+		expect(result.hops).toHaveLength(2);
+		expect(result.hops[0].port).toBe(registry.port);
+		expect(result.hops[1].port).toBe(registrar.port);
+		expect(result.fields["Registry Domain ID"]).toBe("12345");
+		expect(result.fields["Registrar Abuse Contact Email"]).toBe(
+			"abuse@registrar.test",
+		);
+		expect(result.fields["Name Server"]).toEqual([
+			"ns1.registry.test",
+			"ns2.registry.test",
+			"ns3.registrar.test",
+			"ns4.registrar.test",
+		]);
+		expect(result.fields["Domain Name"]).toEqual([
+			"example.test",
+			"example.test",
+		]);
+		expect(result.raw).toContain("Registrar: Test Registrar");
+	});
+
+	test("caps following at the requested referral depth", async () => {
+		const result = await whois("c1.test", {
+			server: "127.0.0.1",
+			port: chain1.port,
+			follow: 1,
+		});
+		expect(result.hops).toHaveLength(2);
+		expect(chain3.state.connections).toBe(0);
+	});
+
+	test("follows multiple referrals when depth allows", async () => {
+		const result = await whois("c1.test", {
+			server: "127.0.0.1",
+			port: chain1.port,
+			follow: 2,
+		});
+		expect(result.hops).toHaveLength(3);
+		expect(result.fields.Result).toBe("deep");
+	});
+
+	test("stops on a referral loop", async () => {
+		const result = await whois("loop.test", {
+			server: "127.0.0.1",
+			port: loopA.port,
+			follow: 5,
+		});
+		expect(result.hops).toHaveLength(2);
+		expect(loopA.state.connections).toBeGreaterThanOrEqual(1);
+		expect(loopB.state.connections).toBeGreaterThanOrEqual(1);
+	});
+
+	test("bootstraps via IANA when no server is given", async () => {
+		const result = await whois("example.test", {
+			bootstrapServer: "127.0.0.1",
+			bootstrapPort: iana.port,
+		});
+		expect(result.hops).toHaveLength(2);
+		expect(result.fields["Registry Domain ID"]).toBe("12345");
+		expect(result.fields["Registrar Abuse Contact Email"]).toBe(
+			"abuse@registrar.test",
+		);
+	});
+
+	test("throws when IANA returns no referral", async () => {
+		await expect(
+			whois("x.test", {
+				bootstrapServer: "127.0.0.1",
+				bootstrapPort: noRefer.port,
+			}),
+		).rejects.toThrow(/No WHOIS server found/);
+	});
+
+	test("throws when the IANA referral is unparseable", async () => {
+		await expect(
+			whois("x.test", {
+				bootstrapServer: "127.0.0.1",
+				bootstrapPort: badRefer.port,
+			}),
+		).rejects.toThrow(/No WHOIS server found/);
+	});
+
+	test("rejects when a referral host is unreachable", async () => {
+		await expect(
+			whois("x.test", {
+				server: "127.0.0.1",
+				port: noPortRefer.port,
+				follow: 1,
+				timeout: 2000,
+			}),
+		).rejects.toThrow();
+	});
+
+	test("defaults the server port when only a host is given", async () => {
+		// No port -> defaults to 43, where nothing listens, so this rejects.
+		await expect(
+			whois("x.test", { server: "127.0.0.1", follow: false, timeout: 1000 }),
+		).rejects.toThrow();
+	});
+
+	test("defaults the bootstrap port when only a bootstrap host is given", async () => {
+		await expect(
+			whois("x.test", { bootstrapServer: "127.0.0.1", timeout: 1000 }),
+		).rejects.toThrow();
+	});
+});
+
+describe("whois caching", () => {
+	test("caches results and serves repeats from cache", async () => {
+		const cache = new Cacheable();
+		const result1 = await whois("counted.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+			cache,
+		});
+		const after = counter.state.connections;
+		const result2 = await whois("counted.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+			cache,
+		});
+		expect(counter.state.connections).toBe(after);
+		expect(result2).toEqual(result1);
+	});
+
+	test("coalesces concurrent identical lookups", async () => {
+		const cache = new Cacheable();
+		const before = counter.state.connections;
+		await Promise.all([
+			whois("coalesce.test", {
+				server: "127.0.0.1",
+				port: counter.port,
+				follow: false,
+				cache,
+			}),
+			whois("coalesce.test", {
+				server: "127.0.0.1",
+				port: counter.port,
+				follow: false,
+				cache,
+			}),
+		]);
+		expect(counter.state.connections - before).toBe(1);
+	});
+
+	test("does not cache when caching is disabled", async () => {
+		const cache = new Cacheable();
+		const before = counter.state.connections;
+		const options = {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+			caching: false,
+			cache,
+		};
+		await whois("nocache.test", options);
+		await whois("nocache.test", options);
+		expect(counter.state.connections - before).toBe(2);
+	});
+
+	test("does not cache without a cache instance", async () => {
+		const before = counter.state.connections;
+		const options = {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		};
+		await whois("free.test", options);
+		await whois("free.test", options);
+		expect(counter.state.connections - before).toBe(2);
+	});
+
+	test("reuses the cached server mapping to skip IANA", async () => {
+		const cache = new Cacheable();
+		const before = iana.state.connections;
+		await whois("first.test", {
+			bootstrapServer: "127.0.0.1",
+			bootstrapPort: iana.port,
+			follow: false,
+			cache,
+		});
+		await whois("second.test", {
+			bootstrapServer: "127.0.0.1",
+			bootstrapPort: iana.port,
+			follow: false,
+			cache,
+		});
+		expect(iana.state.connections - before).toBe(1);
+	});
+
+	test("caches the server mapping for IP queries", async () => {
+		const cache = new Cacheable();
+		const result = await whois("8.8.8.8", {
+			bootstrapServer: "127.0.0.1",
+			bootstrapPort: iana.port,
+			follow: false,
+			cache,
+		});
+		expect(result.type).toBe("ipv4");
+		expect(await cache.get("whois:server:ipv4:8.8.8.8")).toBeDefined();
+	});
+
+	test("does not cache failed lookups", async () => {
+		const cache = new Cacheable();
+		const before = silent.state.connections;
+		const options = {
+			server: "127.0.0.1",
+			port: silent.port,
+			follow: false,
+			timeout: 150,
+			cache,
+		};
+		await expect(whois("err.test", options)).rejects.toThrow();
+		await expect(whois("err.test", options)).rejects.toThrow();
+		expect(silent.state.connections - before).toBe(2);
+	});
+});
+
+describe("whoisRaw", () => {
+	test("returns only the raw text", async () => {
+		const raw = await whoisRaw("counted.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		});
+		expect(typeof raw).toBe("string");
+		expect(raw).toContain("Domain Name: counted.test");
+	});
+});
+
+describe("CacheableNet.whois", () => {
+	test("uses the instance cache for repeat lookups", async () => {
+		const instance = new CacheableNet();
+		const before = counter.state.connections;
+		await instance.whois("inst.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		});
+		const mid = counter.state.connections;
+		await instance.whois("inst.test", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		});
+		expect(mid - before).toBe(1);
+		expect(counter.state.connections).toBe(mid);
+	});
+
+	test("bypasses the cache when caching is false", async () => {
+		const instance = new CacheableNet();
+		const before = counter.state.connections;
+		const options = {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+			caching: false,
+		};
+		await instance.whois("instnc.test", options);
+		await instance.whois("instnc.test", options);
+		expect(counter.state.connections - before).toBe(2);
+	});
+});
+
+describe("whois query types", () => {
+	test("detects IPv4 queries", async () => {
+		const result = await whois("8.8.8.8", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		});
+		expect(result.type).toBe("ipv4");
+	});
+
+	test("detects ASN queries", async () => {
+		const result = await whois("AS15169", {
+			server: "127.0.0.1",
+			port: counter.port,
+			follow: false,
+		});
+		expect(result.type).toBe("asn");
+	});
+});


### PR DESCRIPTION
## Summary

Adds cached **WHOIS** and **RDAP** lookups to `@cacheable/net`, inspired by [`freewhois`](https://github.com/joshterrill/freewhois) but built to be scalable, fully tested, and to provide **both raw and JSON output**.

`freewhois` is RDAP-only, JSON-only, uncached, and ships a static `tlds.json`. This implementation:

- Supports **both protocols**: traditional WHOIS (TCP port 43, raw text → parsed JSON) and RDAP (HTTPS → native JSON).
- Discovers the authoritative server **dynamically via IANA** and caches the mapping — no static TLD list to maintain.
- **Caches results** (and coalesces concurrent identical lookups) via the package's existing `Cacheable` instance, which matters because WHOIS/RDAP servers are heavily rate-limited.
- Works for **domains, IPv4, IPv6, and ASNs**.

## API

```js
import { CacheableNet, whois, whoisRaw, rdap } from '@cacheable/net';

const net = new CacheableNet();

// WHOIS — raw text + parsed JSON
const { raw, fields, hops, server, type } = await net.whois('example.com');

// raw text only
const text = await whoisRaw('8.8.8.8');

// RDAP — native JSON + raw
const { data, raw: rdapRaw } = await net.rdap('AS15169');
```

Standalone functions (`whois`, `whoisRaw`, `rdap`) and helpers (`queryWhoisServer`, `parseWhois`, `normalizeWhoisQuery`, `detectQueryType`) are also exported, mirroring the existing `fetch`/`get`/`post` pattern.

### Highlights
- WHOIS over Node's built-in `node:net` — no new runtime dependencies.
- Registry → registrar referral following with depth caps and loop protection (visited set).
- Generic WHOIS text parser: skips comments (`%`, `#`, `>>>`, `*`), groups repeated keys (e.g. `Name Server`) into arrays.
- RDAP discovery via the IANA bootstrap registries (domains, IPv4/IPv6 CIDR matching, ASN ranges), fetched through the library's own cached `fetch`.
- Per-lookup `caching: false`, `follow`, `timeout`, `server`/`port` overrides, custom `ttl`, and more.

## Testing
- New `test/whois.test.ts` and `test/rdap.test.ts` use local `node:net` / `node:http` fake servers — **no real internet access**.
- **100% coverage** on `whois.ts` and `rdap.ts` (60 tests). The only `v8 ignore`d lines are the production-only real-IANA default endpoints, which can't be exercised without live network.
- `biome` lint passes; package builds to dual CJS/ESM with type declarations; all new exports verified to load under both `import()` and `require()`.

## Docs
- New "WHOIS and RDAP Lookups" section in the package README (with options tables and result shapes), plus Features/TOC entries.
- Also fixes a pre-existing copy-paste bug in `package.json` (`repository.directory` was `packages/cacheable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153VmEzvkNSLQCcNLhhEs5h

---
_Generated by [Claude Code](https://claude.ai/code/session_0153VmEzvkNSLQCcNLhhEs5h)_