### PR TITLE
feat(cacheable): add getStaticInstance shared singleton accessor

### DIFF
--- a/packages/cacheable/README.md
+++ b/packages/cacheable/README.md
@@ -902,7 +902,7 @@ _This does not enable statistics for your layer 2 cache as that is a distributed
 * `removeListener(event, callback)`: Removes a listener.
 * `hash(object: any, algorithm = 'SHA-256'): Promise<string>`: Asynchronously hashes an object with a cryptographic algorithm (SHA-256, SHA-384, SHA-512). Default is `SHA-256`.
 * `hashSync(object: any, algorithm = 'djb2'): string`: Synchronously hashes an object with a non-cryptographic algorithm (djb2, fnv1, murmer, crc32). Default is `djb2`.
-* `getStaticInstance(options?)`: Static. Gets a shared singleton instance, creating it on the first call. Options apply only on first creation.
+* `getStaticInstance(options?)`: Static. Gets a shared singleton instance, creating it on the first call. Options apply only on first creation; passing options after init emits an `error` event and is otherwise ignored.
 * `setStaticInstance(instance?)`: Static. Sets or clears the shared singleton instance. Pass `undefined` to reset it.
 * `primary`: The primary store for the cache (layer 1) defaults to in-memory by Keyv.
 * `secondary`: The secondary store for the cache (layer 2) usually a persistent cache by Keyv.
@@ -925,7 +925,7 @@ await cache.set('key', 'value');
 const same = Cacheable.getStaticInstance();
 ```
 
-Options are only applied when the instance is first created. Any options passed on later calls are ignored and the existing instance is returned.
+Options are only applied when the instance is first created. If you pass options again after the instance already exists, they are ignored and an `error` event is emitted on the instance to surface the conflict — listen with `cache.on('error', ...)`. To reconfigure, replace the instance with `setStaticInstance()` (shown below).
 
 You can replace or reset the shared instance with `setStaticInstance()`. Pass a `Cacheable` instance to swap it, or `undefined` to clear it so the next `getStaticInstance()` call creates a fresh one:
 
@@ -945,6 +945,7 @@ Things to know:
 * The shared instance is process-global and long-lived. Calling `clear()` or `disconnect()` on it affects every part of your app that uses it.
 * After `disconnect()`, `getStaticInstance()` keeps returning the same (now disconnected) instance — it is not recreated automatically. Call `setStaticInstance(undefined)` first, then `getStaticInstance()` to get a fresh one.
 * `setStaticInstance(undefined)` only drops the reference; it does not `disconnect()` or `clear()` the previous instance, so disconnect it first if it holds open connections.
+* This package ships separate CommonJS and ESM builds. An app (or dependency graph) that loads both formats gets one shared instance *per build*, not one process-wide. For a single shared cache, use one module format, or create the instance once and share it via `setStaticInstance()`.
 
 # CacheableMemory - In-Memory Cache
 

--- a/packages/cacheable/README.md
+++ b/packages/cacheable/README.md
@@ -43,6 +43,7 @@
 * [Cacheable Options](#cacheable-options)
 * [Cacheable Statistics (Instance Only)](#cacheable-statistics-instance-only)
 * [Cacheable - API](#cacheable---api)
+* [Static Instance (Singleton)](#static-instance-singleton)
 * [CacheableMemory - In-Memory Cache](#cacheablememory---in-memory-cache)
 * [Keyv Storage Adapter - KeyvCacheableMemory](#keyv-storage-adapter---keyvcacheablememory)
 * [Wrap / Memoization for Sync and Async Functions](#wrap--memoization-for-sync-and-async-functions)
@@ -901,12 +902,49 @@ _This does not enable statistics for your layer 2 cache as that is a distributed
 * `removeListener(event, callback)`: Removes a listener.
 * `hash(object: any, algorithm = 'SHA-256'): Promise<string>`: Asynchronously hashes an object with a cryptographic algorithm (SHA-256, SHA-384, SHA-512). Default is `SHA-256`.
 * `hashSync(object: any, algorithm = 'djb2'): string`: Synchronously hashes an object with a non-cryptographic algorithm (djb2, fnv1, murmer, crc32). Default is `djb2`.
+* `getStaticInstance(options?)`: Static. Gets a shared singleton instance, creating it on the first call. Options apply only on first creation.
+* `setStaticInstance(instance?)`: Static. Sets or clears the shared singleton instance. Pass `undefined` to reset it.
 * `primary`: The primary store for the cache (layer 1) defaults to in-memory by Keyv.
 * `secondary`: The secondary store for the cache (layer 2) usually a persistent cache by Keyv.
 * `namespace`: The namespace for the cache. Default is `undefined`. This will set the namespace for the primary and secondary stores.
 * `maxTtl`: The maximum time to live for any cache entry. When set, TTLs exceeding this value are capped. Default is `undefined` (no maximum).
 * `nonBlocking`: If the secondary store is non-blocking. Default is `false`.
 * `stats`: The statistics for this instance which includes `hits`, `misses`, `sets`, `deletes`, `clears`, `errors`, `count`, `vsize`, `ksize`.
+
+# Static Instance (Singleton)
+
+If you want a single cache shared across your application without constructing a `Cacheable` instance and passing it around, use the static `getStaticInstance()` accessor. The first call creates the shared instance; every later call returns that same instance:
+
+```javascript
+import { Cacheable } from 'cacheable';
+
+const cache = Cacheable.getStaticInstance({ ttl: '1h' });
+await cache.set('key', 'value');
+
+// Anywhere else in your app, the same instance is returned:
+const same = Cacheable.getStaticInstance();
+```
+
+Options are only applied when the instance is first created. Any options passed on later calls are ignored and the existing instance is returned.
+
+You can replace or reset the shared instance with `setStaticInstance()`. Pass a `Cacheable` instance to swap it, or `undefined` to clear it so the next `getStaticInstance()` call creates a fresh one:
+
+```javascript
+import { Cacheable } from 'cacheable';
+import KeyvRedis from '@keyv/redis';
+
+// Provide a fully configured instance as the shared one
+Cacheable.setStaticInstance(new Cacheable({ secondary: new KeyvRedis('redis://localhost:6379') }));
+
+// Reset back to no shared instance
+Cacheable.setStaticInstance(undefined);
+```
+
+Things to know:
+
+* The shared instance is process-global and long-lived. Calling `clear()` or `disconnect()` on it affects every part of your app that uses it.
+* After `disconnect()`, `getStaticInstance()` keeps returning the same (now disconnected) instance — it is not recreated automatically. Call `setStaticInstance(undefined)` first, then `getStaticInstance()` to get a fresh one.
+* `setStaticInstance(undefined)` only drops the reference; it does not `disconnect()` or `clear()` the previous instance, so disconnect it first if it holds open connections.
 
 # CacheableMemory - In-Memory Cache
 

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -70,6 +70,7 @@ export type CacheableHookHandlerMap = {
 };
 
 export class Cacheable extends Hookified {
+	private static _instance?: Cacheable;
 	private _primary: Keyv = createKeyv();
 	private _secondary: Keyv | undefined;
 	private _nonBlocking = false;
@@ -139,6 +140,37 @@ export class Cacheable extends Hookified {
 			// Subscribe to sync events to update local cache
 			this._sync.subscribe(this._primary, this._cacheId);
 		}
+	}
+
+	/**
+	 * Gets a shared static (singleton) instance of {@link Cacheable}. The first call creates the
+	 * instance using the provided options; every later call returns that same instance and ignores
+	 * any options passed. Use this when you want a single global cache shared across your
+	 * application without constructing and passing an instance around. To reset or reconfigure it,
+	 * use {@link Cacheable.setStaticInstance} (pass `undefined` to clear it).
+	 * @param {CacheableOptions} [options] Options applied only when the instance is first created
+	 * @returns {Cacheable} The shared static instance
+	 * @example
+	 * ```ts
+	 * const cache = Cacheable.getStaticInstance({ ttl: "1h" });
+	 * await cache.set("key", "value");
+	 * ```
+	 */
+	public static getStaticInstance(options?: CacheableOptions): Cacheable {
+		Cacheable._instance ??= new Cacheable(options);
+		return Cacheable._instance;
+	}
+
+	/**
+	 * Sets or clears the shared static instance returned by {@link Cacheable.getStaticInstance}.
+	 * Pass a {@link Cacheable} instance to make it the shared instance, or `undefined` to clear it
+	 * so the next {@link Cacheable.getStaticInstance} call creates a fresh one. Clearing only drops
+	 * the reference — it does not `disconnect()` or `clear()` the previous instance, so disconnect
+	 * it first if it holds open connections.
+	 * @param {Cacheable} [instance] The instance to share, or `undefined` to clear it
+	 */
+	public static setStaticInstance(instance?: Cacheable): void {
+		Cacheable._instance = instance;
 	}
 
 	/**

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -144,10 +144,15 @@ export class Cacheable extends Hookified {
 
 	/**
 	 * Gets a shared static (singleton) instance of {@link Cacheable}. The first call creates the
-	 * instance using the provided options; every later call returns that same instance and ignores
-	 * any options passed. Use this when you want a single global cache shared across your
-	 * application without constructing and passing an instance around. To reset or reconfigure it,
-	 * use {@link Cacheable.setStaticInstance} (pass `undefined` to clear it).
+	 * instance using the provided options; every later call returns that same instance. Passing
+	 * `options` again after the instance already exists does NOT reconfigure it — the options are
+	 * ignored and a {@link CacheableEvents.ERROR} event is emitted on the instance to surface the
+	 * conflict (listen with `instance.on("error", ...)`). To reconfigure, replace it via
+	 * {@link Cacheable.setStaticInstance} (clear with `undefined`, then call this again).
+	 *
+	 * Note: this package ships separate CommonJS and ESM builds, so an app that loads both formats
+	 * gets one shared instance per build. For a single shared cache, use one module format or share
+	 * an explicit instance via {@link Cacheable.setStaticInstance}.
 	 * @param {CacheableOptions} [options] Options applied only when the instance is first created
 	 * @returns {Cacheable} The shared static instance
 	 * @example
@@ -157,6 +162,15 @@ export class Cacheable extends Hookified {
 	 * ```
 	 */
 	public static getStaticInstance(options?: CacheableOptions): Cacheable {
+		if (options && Cacheable._instance) {
+			Cacheable._instance.emit(
+				CacheableEvents.ERROR,
+				new Error(
+					"Cacheable static instance is already initialized; the options passed were ignored. To reconfigure, use Cacheable.setStaticInstance().",
+				),
+			);
+			return Cacheable._instance;
+		}
 		Cacheable._instance ??= new Cacheable(options);
 		return Cacheable._instance;
 	}

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -1993,3 +1993,39 @@ describe("cacheable maxTtl", () => {
 		expect(raw.expires).toBeLessThanOrEqual(now + 210);
 	});
 });
+
+describe("Cacheable static instance", () => {
+	beforeEach(() => {
+		Cacheable.setStaticInstance(undefined);
+	});
+	afterEach(() => {
+		Cacheable.setStaticInstance(undefined);
+	});
+	test("should return a Cacheable instance", () => {
+		expect(Cacheable.getStaticInstance()).toBeInstanceOf(Cacheable);
+	});
+	test("should return the same instance on repeated calls", () => {
+		const first = Cacheable.getStaticInstance();
+		expect(Cacheable.getStaticInstance()).toBe(first);
+	});
+	test("should apply options when first created", () => {
+		const instance = Cacheable.getStaticInstance({ cacheId: "static-1" });
+		expect(instance.cacheId).toBe("static-1");
+	});
+	test("should ignore options after the instance is created", () => {
+		const first = Cacheable.getStaticInstance({ cacheId: "static-1" });
+		const second = Cacheable.getStaticInstance({ cacheId: "static-2" });
+		expect(second).toBe(first);
+		expect(second.cacheId).toBe("static-1");
+	});
+	test("should replace the instance with setStaticInstance", () => {
+		const replacement = new Cacheable({ cacheId: "replacement" });
+		Cacheable.setStaticInstance(replacement);
+		expect(Cacheable.getStaticInstance()).toBe(replacement);
+	});
+	test("should clear the instance with setStaticInstance(undefined)", () => {
+		const first = Cacheable.getStaticInstance();
+		Cacheable.setStaticInstance(undefined);
+		expect(Cacheable.getStaticInstance()).not.toBe(first);
+	});
+});

--- a/packages/cacheable/test/index.test.ts
+++ b/packages/cacheable/test/index.test.ts
@@ -2012,11 +2012,16 @@ describe("Cacheable static instance", () => {
 		const instance = Cacheable.getStaticInstance({ cacheId: "static-1" });
 		expect(instance.cacheId).toBe("static-1");
 	});
-	test("should ignore options after the instance is created", () => {
+	test("should emit an error and ignore options when called with options after creation", () => {
 		const first = Cacheable.getStaticInstance({ cacheId: "static-1" });
+		let emitted: Error | undefined;
+		first.on(CacheableEvents.ERROR, (error: Error) => {
+			emitted = error;
+		});
 		const second = Cacheable.getStaticInstance({ cacheId: "static-2" });
 		expect(second).toBe(first);
 		expect(second.cacheId).toBe("static-1");
+		expect(emitted).toBeInstanceOf(Error);
 	});
 	test("should replace the instance with setStaticInstance", () => {
 		const replacement = new Cacheable({ cacheId: "replacement" });


### PR DESCRIPTION
## Summary

Adds a static singleton accessor to the `Cacheable` class so callers can use one shared cache across an application without constructing and threading an instance around. There was previously no shared/default instance — every usage required `new Cacheable(...)`.

- **`Cacheable.getStaticInstance(options?)`** — lazily creates a shared instance on the first call and returns that same instance thereafter.
- **`Cacheable.setStaticInstance(instance?)`** — replaces the shared instance, or clears it with `undefined` (the reset path, handy for tests and reconfiguring).

```ts
import { Cacheable } from "cacheable";

const cache = Cacheable.getStaticInstance({ ttl: "1h" });
await cache.set("key", "value");

// Same instance returned anywhere else:
const same = Cacheable.getStaticInstance();
```

## Behavior notes

- Options are applied **only** when the instance is first created; later calls return the existing instance and ignore options (documented in the JSDoc and README).
- The shared instance is process-global and long-lived — `clear()`/`disconnect()` on it affect every caller. After `disconnect()` it is not auto-recreated; call `setStaticInstance(undefined)` then `getStaticInstance()` for a fresh one.
- `setStaticInstance(undefined)` only drops the reference; it does not `disconnect()`/`clear()` the previous instance.

## Changes

- `packages/cacheable/src/index.ts` — `private static _instance` field plus the two static methods (lazy init via `??=`). No new exports needed (static members on the already-exported class).
- `packages/cacheable/test/index.test.ts` — new `describe` block (6 tests) covering identity, first-call options, options-ignored-after-creation, replace, and reset. The singleton is reset in `beforeEach`/`afterEach` to avoid cross-test pollution; both `??=` branches are exercised.
- `packages/cacheable/README.md` — new "Static Instance (Singleton)" section, a TOC entry, and two API bullets.

## Testing

- `pnpm lint` — passes (no fixes needed).
- `pnpm build` — passes (CJS + ESM + types).
- `pnpm test` (cacheable package) — the 6 new tests pass; 127 of 139 tests pass. The 12 failures are pre-existing sync/`KeyvStorageAdapter` tests that require Redis (`ECONNREFUSED 127.0.0.1:6379`), which isn't available in the local sandbox — they pass in CI where Redis is started via Docker. This change touches no sync/Redis code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JastxGGo1xPEJFy8N9YBpe

---
_Generated by [Claude Code](https://claude.ai/code/session_01JastxGGo1xPEJFy8N9YBpe)_