### PR TITLE
mono - chore: upgrade TypeScript to 6 (breaking)

### DIFF
--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -72,6 +72,6 @@
     "cache-manager-redis-yet": "^5.1.5",
     "cacheable": "workspace:^",
     "tsdown": "^0.22.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -59,6 +59,6 @@
 		"express": "^5.2.1",
 		"pify": "^6.1.0",
 		"tsup": "^8.5.1",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	}
 }

--- a/packages/cacheable-request/tsconfig.build.json
+++ b/packages/cacheable-request/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
     "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src"
+    },
     "include": ["src/**/*"]
 }
   

--- a/packages/cacheable/package.json
+++ b/packages/cacheable/package.json
@@ -40,7 +40,7 @@
 		"@qified/redis": "^0.10.1",
 		"lru-cache": "^11.3.6",
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"@cacheable/memory": "workspace:^",

--- a/packages/file-entry-cache/package.json
+++ b/packages/file-entry-cache/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"pino": "^10.3.1",
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"flat-cache": "workspace:^"

--- a/packages/flat-cache/package.json
+++ b/packages/flat-cache/package.json
@@ -67,7 +67,7 @@
 	},
 	"devDependencies": {
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"cacheable": "workspace:^",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@types/http-cache-semantics": "^4.2.0",
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -49,7 +49,7 @@
 	},
 	"devDependencies": {
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"tsdown": "^0.22.3",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"keywords": [
 		"cacheable",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,10 +99,10 @@ importers:
         version: link:../cacheable
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/cacheable:
     dependencies:
@@ -136,10 +136,10 @@ importers:
         version: 11.3.6
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/cacheable-request:
     dependencies:
@@ -185,10 +185,10 @@ importers:
         version: 6.1.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.23.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/file-entry-cache:
     dependencies:
@@ -201,10 +201,10 @@ importers:
         version: 10.3.1
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/flat-cache:
     dependencies:
@@ -220,10 +220,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/memory:
     dependencies:
@@ -242,10 +242,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/net:
     dependencies:
@@ -270,10 +270,10 @@ importers:
         version: 4.2.0
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/node-cache:
     dependencies:
@@ -289,10 +289,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/utils:
     dependencies:
@@ -305,10 +305,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3)
+        version: 0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/website:
     devDependencies:
@@ -3814,8 +3814,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7267,7 +7267,7 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.26.0(rolldown@1.1.4)(typescript@5.9.3):
+  rolldown-plugin-dts@0.26.0(rolldown@1.1.4)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
@@ -7279,7 +7279,7 @@ snapshots:
       obug: 2.1.3
       rolldown: 1.1.4
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -7622,7 +7622,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@5.9.3):
+  tsdown@0.22.3(@arethetypeswrong/core@0.18.4)(publint@0.3.21)(tsx@4.23.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -7633,7 +7633,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.4
       rolldown: 1.1.4
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.4)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.4)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -7643,7 +7643,7 @@ snapshots:
       '@arethetypeswrong/core': 0.18.4
       publint: 0.3.21
       tsx: 4.23.0
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -7652,7 +7652,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.23.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.23.0)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -7673,7 +7673,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.14
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -7696,7 +7696,7 @@ snapshots:
 
   typescript@5.6.1-rc: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: build-tooling major upgrade with no source changes; existing suites still pass at 100% coverage where runnable in this environment.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — **major** upgrade of the TypeScript compiler `5.9.3` → `6.0.3` across all 9 packages that declare it. This is a `devDependency`/build-tooling change; the emitted JS and `.d.ts` are unchanged in shape, so there is no impact for consumers of the published `@cacheable/*` packages.

### Versions
- `typescript` `^5.9.3` → `^6.0.3` (`cacheable`, `cache-manager`, `cacheable-request`, `file-entry-cache`, `flat-cache`, `@cacheable/memory`, `@cacheable/net`, `@cacheable/node-cache`, `@cacheable/utils`)

### Breaking notes
- **TS6 requires an explicit `rootDir`** when the output layout depends on it (`error TS5011`). This surfaced only in `cacheable-request`, the one package that builds with `tsc` directly. Fix: added `"rootDir": "./src"` to `packages/cacheable-request/tsconfig.build.json`. This is behavior-preserving — it makes explicit what TypeScript previously inferred as the common source directory.
- The `tsdown`-built packages that still use the now-deprecated `moduleResolution: "node"` / `baseUrl` build cleanly — those options don't error under TS 6 through `tsdown`'s declaration generation, so I left them untouched here. Modernizing them (`node` → `bundler`, dropping `baseUrl`) is TS 7 preparation and belongs in its own change, not this compiler bump.
- TS 6.0's changed defaults (`strict`, `types: []`, `module`, `target`) have no effect here because every package sets those options explicitly in its `tsconfig`.

### Verification
- [x] `pnpm build` passes (all 9 packages, incl. the `tsc` build of `cacheable-request`)
- [x] `node scripts/test-build.mjs` (build-output validation: runtime + publint + **attw** on the TS6-generated `.d.ts`) passes for all packages
- [x] `pnpm test` — every package passes at 100% coverage **except the same 3 tests** that fail on `main` and are specific to this sandbox (not caused by this change):
  - `cacheable-request › return with url and port` — real request to external `mockhttp.org:8080`, unreachable here (the `:80` variant passes).
  - `file-entry-cache › should return a file descriptor with checksum and error` and `normalizeEntries() › should return all entries` — both `chmod 0o000` a file to force a read error, but this sandbox runs as **root**, which bypasses permission bits.

  All three pass on GitHub CI (non-root runner, full network).


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_