### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,12 +19,12 @@ jobs:
         node-version: ['26']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -45,6 +45,6 @@ jobs:
         run: pnpm test:ci
 
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 26
         cache: pnpm
@@ -36,7 +36,7 @@ jobs:
       run: pnpm website:build
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # This job only reads the repo (it never pushes), so don't leave the
           # GITHUB_TOKEN in .git/config for later steps / actions to read.
@@ -57,7 +57,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org # writes the .npmrc the registry expects

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,12 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: CI workflow configuration only; no source or dependency changes.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — upgrades every pinned GitHub Action to its latest major. CI-infrastructure only; no impact on the published `@cacheable/*` packages. Marked `(breaking)` because action majors changed.

### Versions (pin style `@vX` preserved)
- `actions/checkout` `v4` → `v7`
- `actions/setup-node` `v4` → `v6`
- `codecov/codecov-action` `v5` → `v7`
- `cloudflare/wrangler-action` `v3` → `v4`
- `pnpm/action-setup` `v6` — already latest, unchanged

### Breaking notes / verification scope
- `checkout`, `setup-node`, and `codecov-action` run in the PR-triggered `tests.yml` (Node 22/24/26) and `codecov.yml` workflows, so **this PR's own CI exercises them**. Standard-input usage (`node-version`, `node-version-file`, `cache: pnpm`, `token`) is unchanged across these majors; `codecov-action` v6+ requires the Node 24 runner, which GitHub-hosted runners provide.
- `cloudflare/wrangler-action` runs **only in `deploy-website.yml` on the `release` event**, so it is *not* exercised by PR CI. Verified by research instead: v4 keeps the `@v`-prefixed tag syntax used here, defaults to Wrangler CLI v4 (already this repo's `wrangler` devDep major), and the `wrangler pages deploy …` invocation is unchanged. `wranglerVersion` is intentionally left unset so the action uses its v4 default.

### Checks
- [x] All four workflow YAML files still parse
- [x] Pin style unchanged (`@vX` major tags)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_