### PR TITLE
benchmark - chore: upgrade tinybench

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -49,7 +49,7 @@
 	"dependencies": {
 		"@faker-js/faker": "^10.5.0",
 		"@monstermann/tinybench-pretty-printer": "^0.3.0",
-		"tinybench": "^6.0.1"
+		"tinybench": "^6.0.2"
 	},
 	"files": [
 		"dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 10.5.0
       '@monstermann/tinybench-pretty-printer':
         specifier: ^0.3.0
-        version: 0.3.0(tinybench@6.0.1)
+        version: 0.3.0(tinybench@6.0.2)
       tinybench:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       '@cacheable/memory':
         specifier: workspace:^
@@ -3503,8 +3503,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinybench@6.0.1:
-    resolution: {integrity: sha512-cMdWsxmysdg8mNWf1pujiWl3TW0cU6m8QuNw55QlnP3I6N96Grb0wnu5N0syHIu3LbiVZCNqlfWzWDq84HZphA==}
+  tinybench@6.0.2:
+    resolution: {integrity: sha512-FlHoQpcFvCzeXK5kVPvV7IVgW/hs/B36QWTz876iSdeJguBDfdTSRQmYmaHX+fQNt4hp+gEFB2XXw+8hT4/y8A==}
     engines: {node: '>=20.0.0'}
 
   tinyexec@0.3.2:
@@ -4444,11 +4444,11 @@ snapshots:
       picocolors: 1.1.1
       string-width: 7.2.0
 
-  '@monstermann/tinybench-pretty-printer@0.3.0(tinybench@6.0.1)':
+  '@monstermann/tinybench-pretty-printer@0.3.0(tinybench@6.0.2)':
     dependencies:
       '@monstermann/tables': 0.0.0
       picocolors: 1.1.1
-      tinybench: 6.0.1
+      tinybench: 6.0.2
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -7285,7 +7285,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinybench@6.0.1: {}
+  tinybench@6.0.2: {}
 
   tinyexec@0.3.2: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency-only patch upgrade.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — first PR of the runtime phase. Patch upgrade of `tinybench` in `@cacheable/benchmark`.

### Versions
- `tinybench` `^6.0.1` → `^6.0.2` (`@cacheable/benchmark`, dependency)

### Verification
- [x] `pnpm build` passes
- [x] `node scripts/test-build.mjs` (build-output validation) passes for all packages
- [x] `pnpm test` — all packages at 100% coverage (and `@cacheable/benchmark` lint passes) except the same 3 pre-existing sandbox-only failures (external `mockhttp.org:8080` unreachable; two `file-entry-cache` tests that rely on `chmod 0o000` failing under a non-root user). All three pass on GitHub CI.
- [x] `@cacheable/benchmark` has no unit tests, so I smoke-tested `tinybench@6.0.2` directly — it imports, constructs a `Bench`, and runs a task successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_