### PR TITLE
mono - chore: upgrade hookified to 3 (breaking)

### DIFF
--- a/packages/cacheable/package.json
+++ b/packages/cacheable/package.json
@@ -45,7 +45,7 @@
 	"dependencies": {
 		"@cacheable/memory": "workspace:^",
 		"@cacheable/utils": "workspace:^",
-		"hookified": "^1.15.0",
+		"hookified": "^3.0.1",
 		"keyv": "^5.6.0",
 		"qified": "^0.12.0"
 	},

--- a/packages/cacheable/src/index.ts
+++ b/packages/cacheable/src/index.ts
@@ -17,7 +17,7 @@ import {
 	shorthandToMilliseconds,
 	wrap,
 } from "@cacheable/utils";
-import { type Hook, Hookified } from "hookified";
+import { type HookFn, Hookified, type IHook } from "hookified";
 import {
 	Keyv,
 	type KeyvEntry,
@@ -86,7 +86,7 @@ export class Cacheable extends Hookified {
 	 * @param {CacheableOptions} [options] The options for the cacheable instance
 	 */
 	constructor(options?: CacheableOptions) {
-		super();
+		super({ throwOnEmptyListeners: false });
 
 		if (options?.primary) {
 			this.setPrimary(options.primary);
@@ -197,10 +197,10 @@ export class Cacheable extends Hookified {
 	public onHook<K extends CacheableHooks>(
 		hook: K,
 		handler: CacheableHookHandlerMap[K],
-	): void;
-	public onHook(event: string, handler: Hook): void;
-	public onHook(event: string, handler: Hook): void {
-		super.onHook(event, handler);
+	): IHook | undefined;
+	public onHook(event: string, handler: HookFn): IHook | undefined;
+	public onHook(event: string, handler: HookFn): IHook | undefined {
+		return super.onHook(event, handler);
 	}
 
 	/**

--- a/packages/cacheable/src/sync.ts
+++ b/packages/cacheable/src/sync.ts
@@ -48,7 +48,7 @@ export class CacheableSync extends Hookified {
 	 * @param options - Configuration options for CacheableSync
 	 */
 	constructor(options: CacheableSyncOptions) {
-		super(options);
+		super({ throwOnEmptyListeners: false, ...options });
 
 		this._namespace = options.namespace;
 		this._qified = this.createQified(options.qified);

--- a/packages/flat-cache/package.json
+++ b/packages/flat-cache/package.json
@@ -72,7 +72,7 @@
 	"dependencies": {
 		"cacheable": "workspace:^",
 		"flatted": "^3.4.2",
-		"hookified": "^1.15.0"
+		"hookified": "^3.0.1"
 	},
 	"files": [
 		"dist",

--- a/packages/flat-cache/src/index.ts
+++ b/packages/flat-cache/src/index.ts
@@ -38,7 +38,7 @@ export class FlatCache extends Hookified {
 	private readonly _parse = parse;
 	private readonly _stringify = stringify;
 	constructor(options?: FlatCacheOptions) {
-		super();
+		super({ throwOnEmptyListeners: false });
 		if (options) {
 			this._cache = new CacheableMemory({
 				ttl: options.ttl,

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -41,7 +41,7 @@
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",
 		"@keyv/bigmap": "^1.3.1",
-		"hookified": "^1.15.1",
+		"hookified": "^3.0.1",
 		"keyv": "^5.6.0"
 	},
 	"keywords": [

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -127,7 +127,7 @@ export class CacheableMemory extends Hookified {
 	 * @param {CacheableMemoryOptions} [options] - The options for the CacheableMemory
 	 */
 	constructor(options?: CacheableMemoryOptions) {
-		super();
+		super({ throwOnEmptyListeners: false });
 
 		if (options?.ttl) {
 			this.setTtl(options.ttl);

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",
 		"cacheable": "workspace:^",
-		"hookified": "^1.15.1",
+		"hookified": "^3.0.1",
 		"http-cache-semantics": "^4.2.0",
 		"undici": "^7.24.5"
 	},

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -113,7 +113,7 @@ export class CacheableNet extends Hookified {
 	private _parse: ParseType = JSON.parse;
 
 	constructor(options?: CacheableNetOptions) {
-		super(options);
+		super({ throwOnEmptyListeners: false, ...options });
 
 		if (options?.cache) {
 			this._cache =

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=22.18.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/node-cache/package.json
+++ b/packages/node-cache/package.json
@@ -53,7 +53,7 @@
 	},
 	"dependencies": {
 		"@cacheable/utils": "workspace:^",
-		"hookified": "^2.1.0",
+		"hookified": "^3.0.1",
 		"keyv": "^5.6.0"
 	},
 	"files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       hookified:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: ^5.6.0
         version: 5.6.0
@@ -215,8 +215,8 @@ importers:
         specifier: ^3.4.2
         version: 3.4.2
       hookified:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       tsdown:
         specifier: ^0.22.3
@@ -234,8 +234,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1(keyv@5.6.0)
       hookified:
-        specifier: ^1.15.1
-        version: 1.15.1
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: ^5.6.0
         version: 5.6.0
@@ -256,8 +256,8 @@ importers:
         specifier: workspace:^
         version: link:../cacheable
       hookified:
-        specifier: ^1.15.1
-        version: 1.15.1
+        specifier: ^3.0.1
+        version: 3.0.1
       http-cache-semantics:
         specifier: ^4.2.0
         version: 4.2.0
@@ -281,8 +281,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       hookified:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: ^5.6.0
         version: 5.6.0
@@ -2349,14 +2349,8 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
-  hookified@1.15.0:
-    resolution: {integrity: sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==}
-
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
-
-  hookified@2.1.0:
-    resolution: {integrity: sha512-ootKng4eaxNxa7rx6FJv2YKef3DuhqbEj3l70oGXwddPQEEnISm50TEZQclqiLTAtilT2nu7TErtCO523hHkyg==}
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
@@ -5713,11 +5707,7 @@ snapshots:
 
   hookable@6.1.1: {}
 
-  hookified@1.15.0: {}
-
   hookified@1.15.1: {}
-
-  hookified@2.1.0: {}
 
   hookified@2.2.0: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency major upgrade; existing suites cover the behavior and stay at 100%.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — **major** upgrade of `hookified` (the event/hooks base class) across the 5 packages that extend it. Marked `(breaking)` because it crosses hookified 2 + 3 and required source changes.

### Versions
- `hookified` `^1.15.0/1/^2.1.0` → `^3.0.1` (`cacheable`, `flat-cache`, `@cacheable/memory`, `@cacheable/net`, `@cacheable/node-cache`)

### Breaking notes / migration
1. **`Hook` type removed → `HookFn`; `onHook` now returns `IHook | undefined`.** In `packages/cacheable/src/index.ts`, changed `import { type Hook }` → `HookFn`, and the `onHook` overloads now return `IHook | undefined` (returning `super.onHook(...)`'s result). The repo's `tsdown` build doesn't type-check source, so I verified this with a real `tsc --noEmit` — otherwise a wrong `.d.ts` would have shipped.
2. **`throwOnEmptyListeners` default flipped `false` → `true`** (in hookified 2). The `getOrSet(…, { cacheErrors: true })` path emits an `"error"` event via `@cacheable/utils/memoize.ts` (7 sites) with no listener — a no-op before, but now it **throws**, so the error propagates instead of being cached. **I restored `throwOnEmptyListeners: false`** in the 4 packages moving from hookified 1.x (`cacheable` ×2, `flat-cache`, `@cacheable/memory`, `@cacheable/net`) to preserve prior behavior. `@cacheable/node-cache` was already on 2.x (`true`) and needed no change.
3. **Node ≥ 22.18** required by hookified 3 — repo is on Node 24 (`.nvmrc`) and CI's `22` resolves to 22.18+, so no change needed.

> 🔸 **Design choice on #2:** since this overrides a default you deliberately changed in `hookified` itself, I went with the behavior-preserving option. If you'd rather **adopt** hookified 3's `true` default instead, the alternative is to guard the emits in `@cacheable/utils` (only `emit("error")` when a listener exists) — happy to switch to that approach.

### Verification
- [x] `pnpm build` passes
- [x] `node scripts/test-build.mjs` (build-output validation, incl. attw) passes for all packages
- [x] `tsc --noEmit` on the 5 packages' source is clean (only the pre-existing `moduleResolution`/`baseUrl` config deprecations, unrelated)
- [x] `pnpm test` — all packages at 100% coverage (the 2 previously-failing `@cacheable/memory` error-caching tests now pass) except the same 3 pre-existing sandbox-only failures (external `mockhttp.org:8080` unreachable; two `file-entry-cache` tests relying on `chmod 0o000` under a non-root user). All three pass on GitHub CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_