### PR TITLE
utils - chore: upgrade hashery to 3 (breaking)

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
 		"clean": "rimraf ./dist ./coverage ./node_modules"
 	},
 	"dependencies": {
-		"hashery": "^1.5.1",
+		"hashery": "^3.0.0",
 		"keyv": "^5.6.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
   packages/utils:
     dependencies:
       hashery:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: ^5.6.0
         version: 5.6.0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency-only upgrade with no source changes.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — runtime phase, **major** upgrade of `hashery` (the hashing library behind `@cacheable/utils`). Marked `(breaking)` for the major bump, though it required no code changes and does not change behavior (see below).

### Versions
- `hashery` `^1.5.1` → `^3.0.0` (`@cacheable/utils`, dependency)

### Breaking notes
- **No code changes required.** `@cacheable/utils`' usage (`new Hashery()` with `toHash` / `toHashSync` / `toNumber` / `toNumberSync` in `src/hash.ts`) is compatible with hashery 3 — verified with a real `tsc --noEmit` (the repo's tsdown build doesn't type-check).
- **Hash output is unchanged**, so cache keys derived from these hashes remain stable across the upgrade. Verified by computing outputs on both versions for fixed input — `sha256`, `djb2`, and both `toNumber` results are byte-identical on 1.5.1 vs 3.0.0.

### Verification
- [x] `pnpm build` + `node scripts/test-build.mjs` pass for all packages
- [x] `pnpm test` — all packages at 100% coverage (utils' 35 hash tests + 247 total pass; downstream `cacheable`/`memory` that hash via utils also green) except the same 3 pre-existing sandbox-only failures (external `mockhttp.org:8080`; two `file-entry-cache` `chmod`-under-root tests). All three pass on GitHub CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_