### PR TITLE
cacheable-request - chore: upgrade normalize-url to 9 (breaking)

### DIFF
--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -48,7 +48,7 @@
 		"http-cache-semantics": "^4.2.0",
 		"keyv": "^5.6.0",
 		"mimic-response": "^4.0.0",
-		"normalize-url": "^8.1.1",
+		"normalize-url": "^9.0.1",
 		"responselike": "^4.0.2"
 	},
 	"devDependencies": {

--- a/packages/cacheable-request/package.json
+++ b/packages/cacheable-request/package.json
@@ -13,7 +13,7 @@
 	"exports": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"scripts": {
 		"lint": "biome check --write --error-on-warnings",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,8 +159,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       normalize-url:
-        specifier: ^8.1.1
-        version: 8.1.1
+        specifier: ^9.0.1
+        version: 9.0.1
       responselike:
         specifier: ^4.0.2
         version: 4.0.2
@@ -2889,9 +2889,9 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
-  normalize-url@8.1.1:
-    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
-    engines: {node: '>=14.16'}
+  normalize-url@9.0.1:
+    resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
+    engines: {node: '>=20'}
 
   nunjucks@3.2.4:
     resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
@@ -6513,7 +6513,7 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  normalize-url@8.1.1: {}
+  normalize-url@9.0.1: {}
 
   nunjucks@3.2.4:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency-only upgrade with no source changes.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — runtime phase, **major** upgrade of `normalize-url` in `cacheable-request`. Marked `(breaking)` for the major bump, though no code changes were needed and cache-key output is unchanged (see below).

### Versions
- `normalize-url` `^8.1.1` → `^9.0.1` (`cacheable-request`, dependency)

### Breaking notes
- **No code changes required.** `cacheable-request`'s `normalizeUrl(...)` usage type-checks against v9 — and because this package builds with `tsc` (`tsc --project tsconfig.build.json`), that's enforced by the build itself.
- **Cache keys are stable.** `normalize-url` feeds cache-key generation, so a changed normalization would silently break consumers' caches. The cache-key assertion tests (e.g. `GET:http://mockhttp.org`, path-stripping, trailing-slash) pass unchanged on v9, confirming the normalized output is the same.

### Verification
- [x] `pnpm build` (incl. cacheable-request's `tsc` build) + `node scripts/test-build.mjs` pass
- [x] `pnpm test` — `cacheable-request` is 65/66 (the sole failure is the pre-existing sandbox-only `return with url and port`, which reaches external `mockhttp.org:8080`; passes on GitHub CI). All other packages remain at 100%.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_