### PR TITLE
net - chore: upgrade undici to 8 (breaking)

### DIFF
--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -44,7 +44,7 @@
 		"cacheable": "workspace:^",
 		"hookified": "^3.0.1",
 		"http-cache-semantics": "^4.2.0",
-		"undici": "^7.24.5"
+		"undici": "^8.6.0"
 	},
 	"keywords": [
 		"cacheable",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       undici:
-        specifier: ^7.24.5
-        version: 7.24.5
+        specifier: ^8.6.0
+        version: 8.6.0
     devDependencies:
       '@types/http-cache-semantics':
         specifier: ^4.2.0
@@ -3658,16 +3658,16 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   undici@8.4.1:
     resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+    engines: {node: '>=22.19.0'}
+
+  undici@8.6.0:
+    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -7419,11 +7419,11 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.24.5: {}
-
   undici@7.28.0: {}
 
   undici@8.4.1: {}
+
+  undici@8.6.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency-only upgrade with no source changes.

**What kind of change does this PR introduce?**

Maintenance (`chore`) — runtime phase, **major** upgrade of `undici` in `@cacheable/net`. The final dependency major of this pass. Marked `(breaking)` for the major bump; no code changes were needed.

### Versions
- `undici` `^7.24.5` → `^8.6.0` (`@cacheable/net`, dependency)

### Breaking notes
- **No code changes required.** `@cacheable/net` uses `undici` only for its **types** (`RequestInit`, `Response`) and re-exports `RequestInit` as `FetchRequestInit`; runtime fetching uses Node's global `fetch` (deliberately, to keep `instanceof` checks aligned with Node's bundled undici). net's source type-checks cleanly against undici 8 — verified with `tsc --noEmit`, since net builds with `tsdown` which doesn't type-check.
- `@cacheable/net` declares no `engines` field, so there's no engine-floor mismatch to reconcile.

### Verification
- [x] `pnpm build` + `node scripts/test-build.mjs` pass for all packages
- [x] `tsc --noEmit` on `@cacheable/net` src is clean against undici 8
- [x] `pnpm test` — `@cacheable/net` passes all 212 tests at 100% coverage; other packages unaffected (undici is net-only). The only repo-wide failures remain the 3 pre-existing sandbox-only ones (`mockhttp.org:8080`; two `file-entry-cache` `chmod`-under-root tests), which pass on GitHub CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_