### PR TITLE
net - chore: upgrade undici to 8.7.0

### DIFF
--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -44,7 +44,7 @@
 		"cacheable": "workspace:^",
 		"hookified": "^3.0.1",
 		"http-cache-semantics": "^4.2.0",
-		"undici": "^8.6.0"
+		"undici": "^8.7.0"
 	},
 	"keywords": [
 		"cacheable",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       undici:
-        specifier: ^8.6.0
-        version: 8.6.0
+        specifier: ^8.7.0
+        version: 8.7.0
     devDependencies:
       '@types/http-cache-semantics':
         specifier: ^4.2.0
@@ -3659,8 +3659,8 @@ packages:
     resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
     engines: {node: '>=22.19.0'}
 
-  undici@8.6.0:
-    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
+  undici@8.7.0:
+    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -7412,7 +7412,7 @@ snapshots:
 
   undici@8.4.1: {}
 
-  undici@8.6.0: {}
+  undici@8.7.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

_No new tests are required — this is a dependency version bump with no behavioral change. `@cacheable/net`'s existing suite (212 tests) continues to pass at 100% coverage._

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — catch-up dependency bump. No runtime or public-API changes.

### Change

**undici 8.6.0 → 8.7.0** in `packages/net`
- Minor release within undici 8, following the undici 8 major migration in #1682.
- `undici` is consumed **type-only** in `@cacheable/net` (`import type { RequestInit, Response } from "undici"` plus a `FetchRequestInit` type re-export). The actual fetch runs through the runtime's own `globalThis.fetch` — a deliberate choice documented in `src/fetch.ts` so body classes (`FormData`, `Blob`, …) satisfy Node's bundled-undici `instanceof` checks. So this bump only refreshes the imported type definitions.
- 8.7.0 is well past the 48h `minimumReleaseAge` window (published 2026-07-04).

### Verification
- `pnpm build` — all packages build.
- `tsc --noEmit` on `packages/net` — clean; undici 8.7.0's `RequestInit`/`Response` types are compatible (tsdown doesn't full type-check, so this is checked explicitly).
- `pnpm --filter @cacheable/net test` — 212/212 pass, coverage maintained.
- `node scripts/test-build.mjs` — runtime import, publint, and attw all pass for every package.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P1TBuMiXotBjpNHYcbwvqf)_