### PR TITLE
cacheable-request - fix: keyv error listener leak on every request

### DIFF
--- a/packages/cacheable-request/src/index.ts
+++ b/packages/cacheable-request/src/index.ts
@@ -315,12 +315,23 @@ class CacheableRequest {
 					ee.emit("error", new CacheError(error));
 				if (this.cache instanceof Keyv) {
 					const cachek = this.cache;
-					cachek.once("error", errorHandler);
-					ee.on("error", () => {
+					// Keyv's event manager wraps once() listeners, so removeListener()
+					// with the original function would never unregister them. Register
+					// with on() and remove the same reference on every termination path
+					// so the listener count stays bounded.
+					const removeErrorHandler = () => {
 						cachek.removeListener("error", errorHandler);
-					});
-					ee.on("response", () => {
-						cachek.removeListener("error", errorHandler);
+					};
+
+					cachek.on("error", errorHandler);
+					ee.on("error", removeErrorHandler);
+					ee.on("response", removeErrorHandler);
+					// Aborted or destroyed requests never emit "response", so clean up
+					// on the underlying request's termination events as well.
+					ee.on("request", (request_: any) => {
+						request_.once("error", removeErrorHandler);
+						request_.once("abort", removeErrorHandler);
+						request_.once("close", removeErrorHandler);
 					});
 				}
 

--- a/packages/cacheable-request/src/index.ts
+++ b/packages/cacheable-request/src/index.ts
@@ -319,8 +319,13 @@ class CacheableRequest {
 					// with the original function would never unregister them. Register
 					// with on() and remove the same reference on every termination path
 					// so the listener count stays bounded.
+					let pendingRequest: any;
 					const removeErrorHandler = () => {
 						cachek.removeListener("error", errorHandler);
+						pendingRequest?.removeListener("error", removeErrorHandler);
+						pendingRequest?.removeListener("abort", removeErrorHandler);
+						pendingRequest?.removeListener("close", removeErrorHandler);
+						pendingRequest = undefined;
 					};
 
 					cachek.on("error", errorHandler);
@@ -329,6 +334,7 @@ class CacheableRequest {
 					// Aborted or destroyed requests never emit "response", so clean up
 					// on the underlying request's termination events as well.
 					ee.on("request", (request_: any) => {
+						pendingRequest = request_;
 						request_.once("error", removeErrorHandler);
 						request_.once("abort", removeErrorHandler);
 						request_.once("close", removeErrorHandler);

--- a/packages/cacheable-request/test/cacheable-request-instance.test.ts
+++ b/packages/cacheable-request/test/cacheable-request-instance.test.ts
@@ -451,3 +451,55 @@ test("cacheableRequest emits CacheError when underlying Keyv emits error event",
 		});
 	});
 });
+
+test("cacheableRequest removes Keyv error listener once the request settles", async () => {
+	const keyv = new Keyv();
+	const cacheableRequest = new CacheableRequest(request, keyv).request();
+	const baseline = keyv.listeners("error").length;
+
+	const get = async (path: string) =>
+		new Promise<void>((resolve, reject) => {
+			cacheableRequest(parseWithWhatwg(`${s.url}${path}`), (response: any) => {
+				response.resume();
+				response.once("end", resolve);
+			})
+				.on("error", reject)
+				.on("request", (request_: any) => request_.end());
+		});
+
+	// Repeated keys are served from cache while fresh keys hit the network;
+	// neither path may leave its error listener behind (issue #1685)
+	for (let index = 0; index < 6; index++) {
+		await get(`/?index=${index % 3}`);
+	}
+
+	await new Promise((resolve) => {
+		setImmediate(resolve);
+	});
+	expect(keyv.listeners("error").length).toBe(baseline);
+});
+
+test("cacheableRequest removes Keyv error listener when the request is aborted", async () => {
+	const keyv = new Keyv();
+	const cacheableRequest = new CacheableRequest(request, keyv).request();
+	const baseline = keyv.listeners("error").length;
+
+	await new Promise<void>((resolve) => {
+		cacheableRequest(parseWithWhatwg(s.url))
+			.on("error", () => {
+				/* swallow abort-induced errors */
+			})
+			.on("request", (request_: any) => {
+				request_.on("error", () => {
+					/* swallow abort-induced socket errors */
+				});
+				request_.once("close", resolve);
+				request_.abort();
+			});
+	});
+
+	await new Promise((resolve) => {
+		setImmediate(resolve);
+	});
+	expect(keyv.listeners("error").length).toBe(baseline);
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix — fixes #1685.

`cacheable-request` registered its per-request Keyv error handler with `cachek.once("error", errorHandler)` and later tried to clean it up with `cachek.removeListener("error", errorHandler)`. Keyv v5's custom event manager wraps `once()` listeners in an anonymous function and `removeListener()` matches by exact reference, so the wrapper was never removed — one `error` listener leaked per request, triggering `MaxListenersExceededWarning: Possible event memory leak detected. 101 error listeners added.` after 100 requests. This is a regression of the original leak fix (jaredwray/cacheable-request#222 / #223) after the Keyv 5 migration.

Changes in `packages/cacheable-request/src/index.ts`:
- Register the handler with `cachek.on("error", errorHandler)` so the shared `removeListener` cleanup removes the exact same reference. Effective once-semantics are preserved: forwarding a Keyv error emits `error` on the request emitter, which itself removes the Keyv listener.
- Also remove the handler on the underlying request's `error`, `abort`, and `close` events, so aborted or destroyed requests that never emit `response`/`error` on the emitter no longer leak the listener.

Tests (`packages/cacheable-request/test/cacheable-request-instance.test.ts`):
- New regression test asserting the Keyv `error` listener count returns to baseline after sequential requests across both the network and cached-response paths (fails with 6 leaked listeners before the fix).
- New regression test asserting the listener is removed when the request is aborted before a response (fails with 1 leaked listener before the fix).
- Verified the exact reproduction script from #1685 against the built package: after 110 sequential requests there are 0 residual listeners and no `MaxListenersExceededWarning`.

`pnpm test` for the package passes (67 tests; statements/lines remain at 100%, branch coverage improves 93.97% → 96.38%). The only failure in this environment is the pre-existing `return with url and port` test, which requires outbound network access to `mockhttp.org` and fails identically on unmodified `main` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tF3VefnzwcH6TQo48uJHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011tF3VefnzwcH6TQo48uJHQ)_